### PR TITLE
Add spec conforming headlines to ADR files

### DIFF
--- a/docs/developer-guide/adrs/000-Use-Markdown-Architectural-Decision-Records.md
+++ b/docs/developer-guide/adrs/000-Use-Markdown-Architectural-Decision-Records.md
@@ -1,21 +1,23 @@
+# Find a Common Way to Document Architectural Design Decsisions
+
 ## Context and Problem Statement
 
 We want to record architectural decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields. Which format and structure should these records follow?
 
 ## Considered Options
 
-* [MADR](https://adr.github.io/madr/) 4.0.0 – The Markdown Architectural Decision Records
-* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
-* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
-* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
-* Formless – No conventions for file format and structure
+- [MADR](https://adr.github.io/madr/) 4.0.0 – The Markdown Architectural Decision Records
+- [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+- [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+- Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+- Formless – No conventions for file format and structure
 
 ## Decision Outcome
 
 Chosen option: "MADR 4.0.0", because
 
-* Implicit assumptions should be made explicit. Design documentation is important to enable people understanding the decisions later on. See also ["A rational design process: How and why to fake it"](https://doi.org/10.1109/TSE.1986.6312940).
-* MADR allows for structured capturing of any decision.
-* The MADR format is lean and fits our development style.
-* The MADR structure is comprehensible and facilitates usage & maintenance.
-* The MADR project is vivid.
+- Implicit assumptions should be made explicit. Design documentation is important to enable people understanding the decisions later on. See also ["A rational design process: How and why to fake it"](https://doi.org/10.1109/TSE.1986.6312940).
+- MADR allows for structured capturing of any decision.
+- The MADR format is lean and fits our development style.
+- The MADR structure is comprehensible and facilitates usage & maintenance.
+- The MADR project is vivid.

--- a/docs/developer-guide/adrs/001-ARC-Architecture.md
+++ b/docs/developer-guide/adrs/001-ARC-Architecture.md
@@ -1,3 +1,5 @@
+# Evaluate Future ARC Architecture Based on Predecessors
+
 ## Context and Problem Statement
 
 This ADR is about finding the right architecture for the ARC suite of services based on the knowledge gained during the internal predecessors of this project.
@@ -151,7 +153,7 @@ An `ArtifactTypeDefinition` specifies the processing rules and workflow template
 - Keep the declarative style of Kubernetes while having complete freedom on the API implementation
 - Argo Workflows allows us to focus on the domain of the product without reinventing the wheel
 - Qotas and Fairness easy without writing code via Kueue
-  
+
 #### Cons
 
 - Building addon apiservers directly on the raw api-machinery libraries requires non-trivial code that must be maintained and rebased as the raw libraries change.

--- a/docs/developer-guide/adrs/002-ARC-API.md
+++ b/docs/developer-guide/adrs/002-ARC-API.md
@@ -1,3 +1,5 @@
+# Define an Optimal API for the Project Beginning
+
 ## Context and Problem Statement
 
 This ADR is about finding the right API for ARC.
@@ -78,11 +80,11 @@ metadata:
 spec:
   rules:
     srcTypes:
-    - s3 # Endpoint Types!
-    - oci
-    - helm
+      - s3 # Endpoint Types!
+      - oci
+      - helm
     dstTypes:
-    - oci
+      - oci
   defaults:
     dstRef: internal-registry
   workflowTemplateRef: # argo.Workflow


### PR DESCRIPTION
ADR Spec defines a headline `#` for each ADR document.