### PR TITLE
Copy labels and annotations from order to subresources

### DIFF
--- a/pkg/controller/artifactworkflow_controller.go
+++ b/pkg/controller/artifactworkflow_controller.go
@@ -216,10 +216,7 @@ func (r *ArtifactWorkflowReconciler) hydrateArgoWorkflow(aw *arcv1alpha1.Artifac
 	}
 
 	wf := &wfv1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      aw.Name,
-			Namespace: aw.Namespace,
-		},
+		ObjectMeta: workflowObjectMeta(aw),
 		Spec: wfv1alpha1.WorkflowSpec{
 			WorkflowTemplateRef: &wfv1alpha1.WorkflowTemplateRef{
 				Name:         aw.Spec.WorkflowTemplateRef.Name,

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -32,11 +32,21 @@ func awName(order *arcv1alpha1.Order, sha string) string {
 	return fmt.Sprintf("%s-%s", order.Name, sha)
 }
 
-func awObjectMeta(order *arcv1alpha1.Order, sha string) metav1.ObjectMeta {
+func cloneObjectMeta(meta metav1.ObjectMeta, name string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Namespace: order.Namespace,
-		Name:      awName(order, sha),
+		Namespace:   meta.Namespace,
+		Name:        name,
+		Labels:      meta.Labels,
+		Annotations: meta.Annotations,
 	}
+}
+
+func awObjectMeta(order *arcv1alpha1.Order, sha string) metav1.ObjectMeta {
+	return cloneObjectMeta(order.ObjectMeta, awName(order, sha))
+}
+
+func workflowObjectMeta(aw *arcv1alpha1.ArtifactWorkflow) metav1.ObjectMeta {
+	return cloneObjectMeta(aw.ObjectMeta, aw.Name)
 }
 
 // TODO: add unit tests


### PR DESCRIPTION
Enhance metadata handling by copying labels and annotations from the order to its subresources, ensuring consistency across related objects.

Closes #100