### PR TITLE
Clear previous error message in order status

### DIFF
--- a/pkg/controller/order_controller.go
+++ b/pkg/controller/order_controller.go
@@ -170,6 +170,7 @@ func (r *OrderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 		desiredAWs[daw.sha] = *daw
 	}
+	order.Status.Message = "" // Clear any previous error message
 
 	// List missing artifact workflows
 	createAWs := []string{}


### PR DESCRIPTION
Clear any previous error message in the order status to ensure accurate status reporting during reconciliation.

Closes #97 