### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -1,4 +1,6 @@
 name: Golang CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/opendefensecloud/artifact-conduit/security/code-scanning/8](https://github.com/opendefensecloud/artifact-conduit/security/code-scanning/8)

To fix this problem, add a `permissions` block to the workflow specifying the minimal privileges required. For these jobs (linting, testing, coverage reporting via Coveralls), `contents: read` should suffice, unless more is required by a third-party action. The best place to add the `permissions` block is at the root of the workflow so that all jobs inherit it unless overridden. Insert the following at line 2 of the workflow YAML (just after the `name:` declaration):

```yaml
permissions:
  contents: read
```

This reduces GITHUB_TOKEN’s permissions for this workflow to read-only access on repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
