### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,4 +1,6 @@
 name: Helm Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/opendefensecloud/artifact-conduit/security/code-scanning/7](https://github.com/opendefensecloud/artifact-conduit/security/code-scanning/7)

To fix the issue, you should explicitly set the `permissions` key in your workflow file to restrict the available scopes for the GITHUB_TOKEN used by the job(s). For Helm linting and templating tasks that only check out code and run commands locally (without modifying the repository, opening pull requests, or commenting on issues), you can safely restrict permissions to `contents: read`. To implement this, add a `permissions` block with at least `contents: read`—either at the root of the workflow (applies to all jobs) or at the job level. In this case, adding it at the root is preferred and simplest, immediately after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
