### PR TITLE
make ginkgo: autodetect version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 OPENAPI_GEN ?= $(LOCALBIN)/openapi-gen
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 
-GINKGO_VERSION ?= v2.27.3
+GINKGO_VERSION ?= $(shell go list -json -m -u github.com/onsi/ginkgo/v2 | jq -r '.Version')
 GOLANGCI_LINT_VERSION ?= v2.5.0
 SETUP_ENVTEST_VERSION ?= release-0.22
 ADDLICENSE_VERSION ?= v1.1.1


### PR DESCRIPTION
This PR updates the `Makefile` to read the required Gingko version from `go.mod`. This is to avoid warnings during tests when Gingko has been updated via the dependabot.