### PR TITLE
Don't use -a flag for go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,20 @@ COPY pkg/ pkg/
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG GO_BUILD_FLAGS
 
 RUN mkdir bin
 
 FROM builder AS apiserver-builder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/arc-apiserver ./cmd/arc-apiserver
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" ${GO_BUILD_FLAGS} -o bin/arc-apiserver ./cmd/arc-apiserver
 
 
 FROM builder AS manager-builder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/arc-controller-manager ./cmd/arc-controller-manager
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" ${GO_BUILD_FLAGS} -o bin/arc-controller-manager ./cmd/arc-controller-manager
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
relates to https://github.com/opendefensecloud/solution-arsenal/pull/204

fixes #220 