### PR TITLE
fix: explictly export secrets for AWS CLI

### DIFF
--- a/examples/blob/cluster-workflow-template.yaml
+++ b/examples/blob/cluster-workflow-template.yaml
@@ -88,6 +88,9 @@ spec:
           if [ "{{workflow.parameters.dstSecret}}" = "true" ]; then
               export AWS_ACCESS_KEY_ID=$(cat /secrets/dst/AWS_ACCESS_KEY_ID)
               export AWS_SECRET_ACCESS_KEY=$(cat /secrets/dst/AWS_SECRET_ACCESS_KEY)
+              if [ -f /secrets/dst/AWS_SESSION_TOKEN ]; then
+                  export AWS_SESSION_TOKEN=$(cat /secrets/dst/AWS_SESSION_TOKEN)
+              fi
           else
               AWS_NO_AUTH="--no-sign-request"
           fi
@@ -140,6 +143,9 @@ spec:
           if [ "{{workflow.parameters.srcSecret}}" = "true" ]; then
               export AWS_ACCESS_KEY_ID=$(cat /secrets/src/AWS_ACCESS_KEY_ID)
               export AWS_SECRET_ACCESS_KEY=$(cat /secrets/src/AWS_SECRET_ACCESS_KEY)
+              if [ -f /secrets/src/AWS_SESSION_TOKEN ]; then
+                  export AWS_SESSION_TOKEN=$(cat /secrets/src/AWS_SESSION_TOKEN)
+              fi
           else
               AWS_NO_AUTH="--no-sign-request"
           fi
@@ -219,6 +225,9 @@ spec:
           if [ "{{workflow.parameters.srcSecret}}" = "true" ]; then
               export AWS_ACCESS_KEY_ID=$(cat /secrets/src/AWS_ACCESS_KEY_ID)
               export AWS_SECRET_ACCESS_KEY=$(cat /secrets/src/AWS_SECRET_ACCESS_KEY)
+              if [ -f /secrets/src/AWS_SESSION_TOKEN ]; then
+                  export AWS_SESSION_TOKEN=$(cat /secrets/src/AWS_SESSION_TOKEN)
+              fi
           else
               AWS_NO_AUTH="--no-sign-request"
           fi
@@ -271,6 +280,9 @@ spec:
           if [ "{{workflow.parameters.dstSecret}}" = "true" ]; then
               export AWS_ACCESS_KEY_ID=$(cat /secrets/dst/AWS_ACCESS_KEY_ID)
               export AWS_SECRET_ACCESS_KEY=$(cat /secrets/dst/AWS_SECRET_ACCESS_KEY)
+              if [ -f /secrets/dst/AWS_SESSION_TOKEN ]; then
+                  export AWS_SESSION_TOKEN=$(cat /secrets/dst/AWS_SESSION_TOKEN)
+              fi
           else
               AWS_NO_AUTH="--no-sign-request"
           fi


### PR DESCRIPTION
Workaround for #187 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched workflow secret handling from env-based injection to explicit source/destination secret mounts per step for clearer secret access.
  * Replaced shared volume anchors with explicit, reusable step-level volume and mount configurations to standardize workspace wiring.

* **Bug Fixes**
  * Ensured each step reads the correct source or destination credentials (or operates without signing) for S3 operations.
  * Adjusted credential initialization order and availability check target so remote checks and upload commands behave correctly when credentials are absent or present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->