### PR TITLE
chore: fix Makefile matching in renovate regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Makefile"
+        "Makefile"
       ],
       "matchStrings": [
         "GOLANGCI_LINT_VERSION \\?= (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
@@ -29,7 +29,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Makefile"
+        "Makefile"
       ],
       "matchStrings": [
         "ADDLICENSE_VERSION \\?= (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
@@ -41,7 +41,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Makefile"
+        "Makefile"
       ],
       "matchStrings": [
         "CONTROLLER_TOOLS_VERSION \\?= (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
@@ -53,7 +53,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Makefile"
+        "Makefile"
       ],
       "matchStrings": [
         "CRD_REF_DOCS_VERSION \\?= (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
@@ -65,7 +65,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Makefile"
+        "Makefile"
       ],
       "matchStrings": [
         "HELM_DOCS_VERSION \\?= (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
@@ -77,7 +77,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Makefile"
+        "Makefile"
       ],
       "matchStrings": [
         "ENVTEST_K8S_VERSION \\?= (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"


### PR DESCRIPTION
Tested locally and in https://github.com/opendefensecloud/renovate-test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve how build tool version updates are tracked and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->