### PR TITLE
chore: get go version used by gh action from devenv.nix

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -16,16 +16,26 @@ on:
 
 env:
   GO_MODULE: https://github.com/opendefensecloud/artifact-conduit
-  GO_VERSION: 1.25.7
 
 jobs:
   lint:
     runs-on: arc-scale-set
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+      - name: get-go-version
+        id: get-go-version
+        run: |
+          GO_VERSION="$(grep -oP 'languages.go.version = "\K[^"]+' devenv.nix)"
+          if [ -z "$GO_VERSION" ]; then
+            echo "::error::Failed to extract Go version from devenv.nix"
+            exit 1
+          fi
+          echo "version=$GO_VERSION" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ steps.get-go-version.outputs.version }}
       - name: lint
         run: |
           make lint
@@ -37,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ needs.lint.outputs.go-version }}
       - name: test
         run: |
           make test

--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,15 @@
       "depNameTemplate": "kubernetes/kubernetes",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)devenv\\.nix$/"],
+      "matchStrings": [
+        "languages\\.go\\.version\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*;"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version"
     }
 
   ],


### PR DESCRIPTION
Checks fail since the go version used by GitHub actions is outdated. Instead of manually bumping the version, use the one from devenv.nix and start tracking that one with renovate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to dynamically manage Go version extraction from development configuration, replacing static version pinning.
  * Enhanced dependency management automation to automatically track and update Go version from development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->