### PR TITLE
fix: trigger golang GitHub action on Makefile changes

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -11,6 +11,7 @@ on:
       - "flake.nix"
       - "go.mod"
       - "go.sum"
+      - "Makefile"
   pull_request:
     branches: [main, develop]
     paths:
@@ -19,6 +20,7 @@ on:
       - "flake.nix"
       - "go.mod"
       - "go.sum"
+      - "Makefile"
 
 env:
   GO_MODULE: https://github.com/opendefensecloud/artifact-conduit


### PR DESCRIPTION
## What
Trigger golang GitHub action on Makefile changes.
Relates to #294

## Why
https://github.com/opendefensecloud/artifact-conduit/pull/320 didn't trigger our unit test but it should have.

## Testing
n/a

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to include additional build trigger paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->