### PR TITLE
test: verify that cron schedules are passed to Argo workflows

### DIFF
--- a/pkg/controller/artifactworkflow_controller_test.go
+++ b/pkg/controller/artifactworkflow_controller_test.go
@@ -365,6 +365,8 @@ var _ = Describe("ArtifactWorkflowController", func() {
 				return k8sClient.Get(ctx, namespacedName(aw.Namespace, aw.Name), &cwf)
 			}).Should(Succeed())
 
+			Expect(cwf.Spec.Schedules).To(Equal([]string{"*/5 * * * *"}))
+
 			// Simulate Argo Workflows creating a Workflow on cron schedule
 			wf := wfv1alpha1.Workflow{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## What
We rely on the cron functionality of Argo workflows. This change verifies that our controller translates the `ArtifactWorkflow` cron schedules spec into Argo's `CronWorkflow` cron schedules spec.

Addresses https://github.com/opendefensecloud/artifact-conduit/pull/315#discussion_r3167230150.

## Testing
n/a

## Checklist
- [x] Tests added/updated --> n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation in cron schedule tests to ensure proper configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->