### PR TITLE
chore: run golang GitHub action on tools.lock changes

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -12,6 +12,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Makefile"
+      - "tools.lock"
   pull_request:
     branches: [main, develop]
     paths:
@@ -21,6 +22,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Makefile"
+      - "tools.lock"
 
 env:
   GO_MODULE: https://github.com/opendefensecloud/artifact-conduit


### PR DESCRIPTION
## What
Golang GitHub action uses tools referenced in tools.lock like addlicense (via `make lint-no-golangci`) or ginkgo (via `make test`).

## Why
Ensure that version bumps in tools.lock don't create regressions by verifying the change with related GitHub actions.

## Testing
none

## Checklist
- [x] Tests added/updated --> n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved
