### PR TITLE
chore: prevent cached results for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ KIND_CLUSTER_E2E ?= arc-test-e2e
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.
 	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_E2E)
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER_E2E) HELM=$(HELM) go test -tags=e2e ./test/e2e/ -v -timeout=1h -ginkgo.v -ginkgo.timeout=1h
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER_E2E) HELM=$(HELM) go test -count=1 -tags=e2e ./test/e2e/ -v -timeout=1h -ginkgo.v -ginkgo.timeout=1h
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e


### PR DESCRIPTION
## What
Same as for Solar: https://github.com/opendefensecloud/solution-arsenal/pull/503

## Why
Go's test cache works by hashing the test binary plus any other state it can observe. For the e2e tests, the results depend on external world state that Go can't observe and so can't hash.      

## Testing
`make test-e2e`

## Checklist
- [x] ~~Tests added/updated~~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E test execution to ensure consistent test runs without relying on cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->