### PR TITLE
chore: use hosted GitHub runners

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,7 +39,7 @@ jobs:
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ok-to-image')) ||
       (github.event_name == 'release' && github.event.action == 'published')
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: docker/metadata-action@v6

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   lint:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.version }}
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   test:
     needs: lint
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   lint:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write # Push to ghcr.io


### PR DESCRIPTION
## What
Relates to https://github.com/opendefensecloud/odd-internal/issues/28.

## Testing
n/a

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration pipeline runners to use Ubuntu 24.04 across all workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/artifact-conduit/pull/352)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->