### PR TITLE
fix: run example ocm workflow as non-root

### DIFF
--- a/examples/ocm/cluster-workflow-template.yaml
+++ b/examples/ocm/cluster-workflow-template.yaml
@@ -8,10 +8,9 @@ spec:
     limit: 1
 
   serviceAccountName: arc-workflow
-  # FIXME: ocm requires permissions to write to /var/lib/registry/docker
-  #  securityContext:
-  #    fsGroup: 65532
-  #    runAsUser: 65532
+  securityContext:
+    fsGroup: 65532
+    runAsUser: 65532
 
   # Mount certificate bundle
   volumes:
@@ -23,6 +22,8 @@ spec:
         items:
           - key: trust-bundle.pem
             path: trust-bundle.pem
+    - name: registry-storage
+      emptyDir: {}
 
   # Define the PVC template for inter-step data sharing
   volumeClaimTemplates:
@@ -83,6 +84,9 @@ spec:
           httpGet:
             path: /v2/_catalog
             port: 5000
+        volumeMounts:
+          - name: registry-storage
+            mountPath: /var/lib/registry
 
     # --- 1. Pull all resources & store them both on disk and registry ---
     - name: pull-resources
@@ -151,6 +155,7 @@ spec:
               --severity {{workflow.parameters.scanSeverity}} \
               --format json \
               --output /data/scan-results.json \
+              --cache-dir /tmp/trivy-cache \
               $p
           done < /data/images.txt
         env:


### PR DESCRIPTION
## What
Closes #261 

## Why
Adjusted two workflow steps:
- oci-registry: Mounted `/var/lib/registry` as empty directory so that the OCI registry can store the uploaded artifacts.
- scan-all-images: Point the cache to `tmp`  that is used by trivy to store the artifacts while scanning to ensure it is writable by non-root.

## Testing
```
make dev-cluster
kubectl apply -f examples/ocm/cluster-workflow-template.yaml
kubectl apply -f examples/ocm/artifact-type.yaml 
kubectl apply -f test/fixtures/ocm-order.yaml
```
## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration for the container registry with improved permission settings.
  * Optimized registry storage handling and cache management for workflow operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/artifact-conduit/pull/356)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->