### PR TITLE
fix: update rbac declaration after events API migration

### DIFF
--- a/charts/arc/files/role.yaml
+++ b/charts/arc/files/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - pods
   - pods/log
   verbs:
@@ -83,3 +76,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/pkg/controller/artifactworkflow_controller.go
+++ b/pkg/controller/artifactworkflow_controller.go
@@ -48,7 +48,7 @@ type ArtifactWorkflowReconciler struct {
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=argoproj.io,resources=workflows,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=argoproj.io,resources=cronworkflows,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=pods;pods/log,verbs=get;list
 
 // Reconcile moves the current state of the cluster closer to the desired state

--- a/pkg/controller/order_controller.go
+++ b/pkg/controller/order_controller.go
@@ -58,7 +58,7 @@ type desiredAW struct {
 //+kubebuilder:rbac:groups=arc.opendefense.cloud,resources=orders/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=arc.opendefense.cloud,resources=orders/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile moves the current state of the cluster closer to the desired state
 func (r *OrderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## What
Closes #357.

## Why
See issue linked above.

## Testing
```
make dev-cluster
kubectl apply -f examples/ocm/cluster-workflow-template.yaml
kubectl apply -f examples/ocm/artifact-type.yaml 
kubectl apply -f test/fixtures/ocm-order.yaml
kubectl -n default describe orders.arc.opendefense.cloud  example-ocm-order
[..]
Events:
  Type    Reason   Age   From              Message
  ----    ------   ----  ----              -------
  Normal  Created  4s    order-controller  Created artifact workflow 'example-ocm-order-bca47a1765c7fa57' for artifact index 0
```

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event permission configuration to ensure proper Kubernetes API compatibility and correct handling of system events across controllers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/artifact-conduit/pull/358)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->