### PR TITLE
fix: adjust Argo v4 installation for dev cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,10 @@ dev-cluster: manifests ## Install all necessary components into local Kind clust
 
 	@echo -e "\nSETTING UP ARGO WORKFLOWS:\n"
 	$(KUBECTL) --context kind-$(KIND_CLUSTER_DEV) create namespace argo || true
-	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n argo -f \
+	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n argo --server-side -f \
 		https://github.com/argoproj/argo-workflows/releases/download/v4.0.5/quick-start-minimal.yaml
+	$(KUBECTL) patch configmap workflow-controller-configmap --context kind-$(KIND_CLUSTER_DEV) -n argo --type=merge -p \
+		'{"data": {"artifactRepository": "archiveLogs: false\n"}}'
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n default -f \
 		test/fixtures/secret.yaml
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n default -f \


### PR DESCRIPTION
## What
Port over Argo v4 installation changes to the dev cluster.

https://github.com/opendefensecloud/artifact-conduit/blob/d6f3ea43bc0822a5874979b711edb280986f8aae/test/e2e/e2e_suite_test.go#L247-L256

## Why
n/a

## Testing
```
make dev-cluster
kubectl apply -f examples/ocm/cluster-workflow-template.yaml
kubectl apply -f examples/ocm/artifact-type.yaml 
kubectl apply -f test/fixtures/ocm-order.yaml
kubectl -n default describe orders.arc.opendefense.cloud  example-ocm-order
```

## Checklist
- [x] ~Tests added/updated~
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
