### PR TITLE
docs: add observability guide

### DIFF
--- a/charts/arc/README.md
+++ b/charts/arc/README.md
@@ -359,7 +359,11 @@ If you're currently using Kustomize to deploy ARC:
 | controller.metrics.certManager.certKey | string | `"tls.key"` | Certificate key file name |
 | controller.metrics.certManager.certName | string | `"tls.crt"` | Certificate file name |
 | controller.metrics.certManager.certPath | string | `"/tmp/k8s-metrics-server/metrics-certs"` | Path to mount certificates |
+| controller.metrics.certManager.duration | string | `""` | Certificate duration; defaults to .Values.certManager.certificate.duration |
 | controller.metrics.certManager.enabled | bool | `false` | Enable cert-manager for metrics certificates |
+| controller.metrics.certManager.issuerRef.kind | string | `""` | Issuer kind (Issuer or ClusterIssuer); defaults to .Values.certManager.issuer.kind |
+| controller.metrics.certManager.issuerRef.name | string | `""` | Issuer name; defaults to arc.certManager.issuerName helper |
+| controller.metrics.certManager.renewBefore | string | `""` | Renew before duration; defaults to .Values.certManager.certificate.renewBefore |
 | controller.metrics.enabled | bool | `false` | Enable metrics service |
 | controller.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | controller.metrics.service.port | int | `8443` | Metrics service port |
@@ -368,6 +372,8 @@ If you're currently using Kustomize to deploy ARC:
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor |
 | controller.metrics.serviceMonitor.interval | string | `"30s"` | Scrape interval |
 | controller.metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout |
+| controller.metrics.serviceMonitor.tokenSecret.key | string | `"token"` | Key within the Secret that holds the token |
+| controller.metrics.serviceMonitor.tokenSecret.name | string | `""` | Name of the Secret containing the scrape bearer token |
 | controller.nameOverride | string | `""` | Override Controller Manager name |
 | controller.nodeSelector | object | `{}` | Node selector for pod assignment |
 | controller.podAnnotations | object | `{}` | Pod annotations |
@@ -391,7 +397,7 @@ If you're currently using Kustomize to deploy ARC:
 | etcd.extraEnv | list | `[]` | Additional environment variables |
 | etcd.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | etcd.image.repository | string | `"quay.io/coreos/etcd"` | etcd image repository |
-| etcd.image.tag | string | `"v3.6.10"` | etcd image tag |
+| etcd.image.tag | string | `"v3.6.11"` | etcd image tag |
 | etcd.imagePullSecrets | list | `[]` | Image pull secrets for etcd |
 | etcd.livenessProbe | object | `{"httpGet":{"path":"/health","port":2379},"initialDelaySeconds":15,"periodSeconds":20}` | Liveness probe configuration |
 | etcd.nodeSelector | object | `{}` | Node selector for pod assignment |

--- a/charts/arc/templates/controller/certificate.yaml
+++ b/charts/arc/templates/controller/certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.controller.enabled .Values.controller.metrics.enabled .Values.controller.metrics.certManager.enabled .Values.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "arc.controller.fullname" . }}-metrics-cert
+  namespace: {{ include "arc.namespace" . }}
+  labels:
+    {{- include "arc.controller.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ include "arc.controller.metricsServiceName" . }}.{{ include "arc.namespace" . }}.svc
+    - {{ include "arc.controller.metricsServiceName" . }}.{{ include "arc.namespace" . }}.svc.cluster.local
+  issuerRef:
+    kind: {{ default .Values.certManager.issuer.kind .Values.controller.metrics.certManager.issuerRef.kind }}
+    name: {{ default (include "arc.certManager.issuerName" .) .Values.controller.metrics.certManager.issuerRef.name }}
+  secretName: {{ include "arc.controller.fullname" . }}-metrics-cert
+  duration: {{ default .Values.certManager.certificate.duration .Values.controller.metrics.certManager.duration }}
+  renewBefore: {{ default .Values.certManager.certificate.renewBefore .Values.controller.metrics.certManager.renewBefore }}
+{{- end }}

--- a/charts/arc/templates/controller/deployment.yaml
+++ b/charts/arc/templates/controller/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - --health-probe-bind-address={{ .Values.controller.args.healthProbeBindAddress }}
             {{- if .Values.controller.metrics.enabled }}
             - --metrics-bind-address={{ .Values.controller.args.metricsBindAddress }}
-            - --metrics-secure={{ .Values.controller.args.metricsSecure }}
+            - --metrics-secure={{ and .Values.controller.args.metricsSecure .Values.controller.metrics.certManager.enabled }}
             {{- if .Values.controller.metrics.certManager.enabled }}
             - --metrics-cert-path={{ .Values.controller.metrics.certManager.certPath }}
             - --metrics-cert-name={{ .Values.controller.metrics.certManager.certName }}

--- a/charts/arc/templates/controller/metrics-service.yaml
+++ b/charts/arc/templates/controller/metrics-service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: {{ .Values.controller.metrics.service.type }}
   ports:
-    - name: https
+    - name: {{ if .Values.controller.metrics.certManager.enabled }}https{{ else }}http{{ end }}
       port: {{ .Values.controller.metrics.service.port }}
       protocol: TCP
       targetPort: {{ .Values.controller.metrics.service.port }}

--- a/charts/arc/templates/controller/servicemonitor.yaml
+++ b/charts/arc/templates/controller/servicemonitor.yaml
@@ -14,10 +14,26 @@ spec:
     matchLabels:
       {{- include "arc.controller.selectorLabels" . | nindent 6 }}
   endpoints:
+    {{- if .Values.controller.metrics.certManager.enabled }}
     - port: https
       scheme: https
-      interval: {{ .Values.controller.metrics.serviceMonitor.interval }}
-      scrapeTimeout: {{ .Values.controller.metrics.serviceMonitor.scrapeTimeout }}
       tlsConfig:
         insecureSkipVerify: true
+      {{- with .Values.controller.metrics.serviceMonitor.tokenSecret.name }}
+      # In secure mode the controller enforces authn/authz on /metrics, so scrape
+      # with a bearer token whose identity is granted GET /metrics via the
+      # {release name}-controller-manager-metrics-reader ClusterRole. The token
+      # is read from a Secret in this namespace.
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ . }}
+          key: {{ $.Values.controller.metrics.serviceMonitor.tokenSecret.key }}
+      {{- end }}
+    {{- else }}
+    - port: http
+      scheme: http
+    {{- end }}
+      interval: {{ .Values.controller.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.controller.metrics.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/charts/arc/values.yaml
+++ b/charts/arc/values.yaml
@@ -226,6 +226,16 @@ controller:
       certName: tls.crt
       # -- Certificate key file name
       certKey: tls.key
+      # Issuer override — leave empty to fall back to the shared certManager issuer
+      issuerRef:
+        # -- Issuer kind (Issuer or ClusterIssuer); defaults to .Values.certManager.issuer.kind
+        kind: ""
+        # -- Issuer name; defaults to arc.certManager.issuerName helper
+        name: ""
+      # -- Certificate duration; defaults to .Values.certManager.certificate.duration
+      duration: ""
+      # -- Renew before duration; defaults to .Values.certManager.certificate.renewBefore
+      renewBefore: ""
 
     # ServiceMonitor for Prometheus Operator
     serviceMonitor:
@@ -237,6 +247,17 @@ controller:
       scrapeTimeout: 10s
       # -- Additional labels for ServiceMonitor
       additionalLabels: {}
+
+      # Bearer-token credentials for scraping the secured (HTTPS) metrics endpoint.
+      # Only used when controller.metrics.certManager.enabled=true, where the
+      # controller enforces authn/authz. Reference a Secret in the release namespace
+      # holding a token for an identity bound to the {release name}controller-manager-metrics-reader
+      # ClusterRole. Leave name empty for the plain-HTTP endpoint (no auth required).
+      tokenSecret:
+        # -- Name of the Secret containing the scrape bearer token
+        name: ""
+        # -- Key within the Secret that holds the token
+        key: token
 
   # -- Resource limits and requests
   resources:

--- a/docs/operator-manual/observability.md
+++ b/docs/operator-manual/observability.md
@@ -1,0 +1,123 @@
+# Observability & Monitoring
+
+ARC exposes [controller-runtime](https://book.kubebuilder.io/reference/metrics-reference.html) Prometheus metrics and Kubernetes health probes. There are no ARC-specific custom metrics; alerting is built on the standard reconciler signals for the `order` and `artifactworkflow` controllers.
+
+## Enabling the Metrics Endpoint
+
+Metrics are **disabled by default**. Enable them via Helm:
+
+> **Note:** `serviceMonitor.enabled` requires the [Prometheus Operator](https://prometheus-operator.dev/) CRDs to be present in the cluster. If you are not using the Prometheus Operator, omit it.
+
+```yaml
+controller:
+  metrics:
+    enabled: true
+    service:
+      port: 8443
+    # Optional: use cert-manager
+    certManager:
+      enabled: true
+      # Optional overrides — defaults to the shared certManager issuer and certificate values
+      issuerRef:
+        kind: Issuer          # or ClusterIssuer
+        name: my-metrics-issuer
+      duration: 2160h
+      renewBefore: 720h
+    serviceMonitor:
+      enabled: true
+      # Required only with certManager (HTTPS) — see "Securing the scrape" below.
+      tokenSecret:
+        name: arc-metrics-scrape-token
+  args:
+    metricsBindAddress: ":8443"
+```
+
+> **HTTP vs HTTPS:** with `certManager.enabled: false` the endpoint is served over plain HTTP and is unauthenticated — no token wiring is needed and `serviceMonitor.tokenSecret` can be omitted. The steps below apply only to the secured (cert-manager/HTTPS) path.
+
+### Securing the scrape
+
+With cert-manager enabled the controller enforces RBAC authn/authz on `GET /metrics`, so Prometheus must present a bearer token. The chart creates the `{release-name}-controller-manager-metrics-reader` ClusterRole (grants `GET /metrics` and nothing else) but does **not** bind it — you wire up a least-privilege scrape identity:
+
+1. Create a ServiceAccount in the ARC release namespace and bind it to the `{release-name}-controller-manager-metrics-reader` ClusterRole (substitute your release name for `arc`):
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: arc-metrics-scraper
+  namespace: arc-system          # the release namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: arc-metrics-scraper-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: arc-controller-manager-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: arc-metrics-scraper
+    namespace: arc-system
+```
+
+2. Create a token for it as a Secret in the ARC release namespace (the ServiceMonitor and its credentials Secret must share a namespace):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: arc-metrics-scrape-token
+  namespace: arc-system           # the release namespace
+  annotations:
+    kubernetes.io/service-account.name: arc-metrics-scraper
+type: kubernetes.io/service-account-token
+```
+
+3. Point the ServiceMonitor at it via `controller.metrics.serviceMonitor.tokenSecret.name` (shown above).
+
+## Health Probes
+
+Always exposed on port `8081`:
+
+| Path       | Purpose                              |
+| ---------- | ------------------------------------ |
+| `/healthz` | Liveness — restart on failure        |
+| `/readyz`  | Readiness — remove from service      |
+
+## Top Health Signals
+
+Monitor these metrics to catch a degraded controller. Each metric carries a `controller` label; watch both `order` and `artifactworkflow`.
+
+| Metric | Signal |
+|--------|--------|
+| `controller_runtime_reconcile_errors_total` | Sustained error rate — reconciler is repeatedly failing |
+| `workqueue_depth` | Queue not draining — reconciler is falling behind |
+| `controller_runtime_reconcile_time_seconds` | High p99 latency — reconciles are slow |
+| `controller_runtime_active_workers` | Equals `controller_runtime_max_concurrent_reconciles` — worker pool saturated |
+
+## Full Metric Catalog
+
+All metrics are emitted per controller (`order`, `artifactworkflow`) or workqueue (`name=order|artifactworkflow`).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `controller_runtime_reconcile_total` | Counter | `controller`, `result` (`success`, `error`, `requeue`, `requeue_after`) | Total reconcile attempts |
+| `controller_runtime_reconcile_errors_total` | Counter | `controller` | Reconciles that returned an error |
+| `controller_runtime_reconcile_time_seconds` | Histogram | `controller` | Reconcile duration |
+| `controller_runtime_active_workers` | Gauge | `controller` | Workers currently reconciling |
+| `controller_runtime_max_concurrent_reconciles` | Gauge | `controller` | Worker pool size |
+| `workqueue_depth` | Gauge | `name`, `priority` | Items waiting in the queue |
+| `workqueue_adds_total` | Counter | `name` | Items added to the queue |
+| `workqueue_queue_duration_seconds` | Histogram | `name` | Wait time before processing |
+| `workqueue_work_duration_seconds` | Histogram | `name` | Processing time per item |
+| `workqueue_retries_total` | Counter | `name` | Requeues due to error/rate-limit |
+| `rest_client_requests_total` | Counter | `code`, `method`, `host` | Kubernetes API calls from the controller |
+
+## Workflow Execution Failures
+
+ARC's controller-runtime metrics cover controller health only — whether ARC successfully handed work to Argo Workflows. Workflow-level failures (a workflow that ran but produced a `Failed` or `Error` outcome) are owned by Argo and are visible through its own Prometheus metrics, which include per-namespace workflow counts broken down by phase.
+
+Add Argo's metrics endpoint to your Prometheus scrape config alongside ARC's, then monitor workflow failures there rather than here. Consult the [Argo Workflows metrics documentation](https://argo-workflows.readthedocs.io/en/latest/metrics/) for details.
+
+See [Failed Workflow Debugging](debugging.md) for log collection details.


### PR DESCRIPTION
## What
Closes #296 

## Why
<!-- Motivation / problem being solved. Skip if obvious from the linked issue. -->

## Testing
I've created a Grafana dashboard, enabled monitoring and checked the top health signals.

## Checklist
- [x] ~Tests added/updated~n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive observability guide covering metrics exposure, health probes (/healthz, /readyz on port 8081), a metric catalog, key health metrics, RBAC binding steps, and guidance for monitoring/debugging workflows.

* **New Features**
  * Helm options to enable TLS for controller metrics via cert-manager, including issuer overrides and certificate timing (duration/renewBefore), conditional secure metrics flag, Service/ServiceMonitor http vs https selection, and optional bearer-token scraping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->