### PR TITLE
fix: renovate for github runners

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,15 @@
       ],
       "versioningTemplate": "semver",
       "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/).github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": [
+        "runs-on:\\s*(?<depName>\\w+)-(?<currentValue>[\\d.]+)"
+      ],
+      "datasourceTemplate": "github-runners",
+      "versioningTemplate": "docker"
     }
   ],
   "ignorePaths": []


### PR DESCRIPTION
## What

Enables Renovate for Github Runners.

Part of [#odd-internal/28](https://github.com/opendefensecloud/odd-internal/issues/28).

## Why
Runners need updates.

## Testing
Not tested.

## Notes for reviewers
...

## Checklist
- [ ] Tests added/updated
- [X] No breaking changes (or upgrade path documented above)
- [X] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved
