### PR TITLE
chore: migrate to github hosted runner

### DIFF
--- a/.github/workflows/docs-develop.yaml
+++ b/.github/workflows/docs-develop.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## What
Closes https://github.com/opendefensecloud/odd-internal/issues/28

## Why
Missed a GitHub action in https://github.com/opendefensecloud/artifact-conduit/pull/352.

## Testing
none

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
