### PR TITLE
feat: track versions for e2e dependencies as environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ DOCS_IMG ?= arc-docs:latest
 
 ENVTEST_K8S_VERSION ?= 1.36.0
 
+export ARGO_WORKFLOWS_VERSION := $(shell awk '/^[ \t]+github.com\/argoproj\/argo-workflows/ {print $$2}' go.mod)
+export CERTMANAGER_VERSION := v1.19.1
+export TRUSTMANAGER_VERSION := v0.20.2
+
 LICENSE := apache
 LICENSE_COMMENT := BWI GmbH and Artifact Conduit contributors
 
@@ -51,7 +55,10 @@ KIND_CLUSTER_E2E ?= arc-test-e2e
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.
 	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_E2E)
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER_E2E) HELM=$(HELM) go test -count=1 -tags=e2e ./test/e2e/ -v -timeout=1h -ginkgo.v -ginkgo.timeout=1h
+	KIND=$(KIND) \
+	KIND_CLUSTER=$(KIND_CLUSTER_E2E) \
+	HELM=$(HELM) \
+	go test -count=1 -tags=e2e ./test/e2e/ -v -timeout=1h -ginkgo.v -ginkgo.timeout=1h
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e
@@ -66,22 +73,22 @@ dev-cluster: manifests ## Install all necessary components into local Kind clust
 	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_DEV)
 	@echo -e "\nSETTING UP CERT-MANAGER:\n"
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -f \
-		https://github.com/cert-manager/cert-manager/releases/download/v1.19.1/cert-manager.yaml
+		https://github.com/cert-manager/cert-manager/releases/download/$(CERTMANAGER_VERSION)/cert-manager.yaml
 	$(KUBECTL) wait deployment.apps/cert-manager-webhook --for condition=Available --namespace cert-manager --timeout 5m
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n cert-manager -f \
 		test/fixtures/certmanager.yaml
 
 	@echo -e "\nSETTING UP TRUST-MANAGER:\n"
-	$(HELM) upgrade --install --namespace=cert-manager trust-manager oci://quay.io/jetstack/charts/trust-manager --version v0.20.2
+	$(HELM) upgrade --install --namespace=cert-manager trust-manager oci://quay.io/jetstack/charts/trust-manager --version $(TRUSTMANAGER_VERSION)
 	$(KUBECTL) wait deployment.apps/trust-manager --for condition=Available --namespace cert-manager --timeout 5m
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n cert-manager -f  \
 		test/fixtures/trustmanager.yaml
-	$(KUBECTL) label  --context kind-$(KIND_CLUSTER_DEV) namespace default trust=enabled --overwrite
+	$(KUBECTL) label --context kind-$(KIND_CLUSTER_DEV) namespace default trust=enabled --overwrite
 
 	@echo -e "\nSETTING UP ARGO WORKFLOWS:\n"
 	$(KUBECTL) --context kind-$(KIND_CLUSTER_DEV) create namespace argo || true
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n argo --server-side -f \
-		https://github.com/argoproj/argo-workflows/releases/download/v4.0.5/quick-start-minimal.yaml
+		https://github.com/argoproj/argo-workflows/releases/download/$(ARGO_WORKFLOWS_VERSION)/quick-start-minimal.yaml
 	$(KUBECTL) patch configmap workflow-controller-configmap --context kind-$(KIND_CLUSTER_DEV) -n argo --type=merge -p \
 		'{"data": {"artifactRepository": "archiveLogs: false\n"}}'
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -n default -f \

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,30 @@
         "image:\\s*(?<depName>[a-zA-Z0-9./_-]+):(?<currentValue>[a-zA-Z0-9._-]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "Makefile"
+      ],
+      "matchStrings": [
+        "CERTMANAGER_VERSION := (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "cert-manager/cert-manager",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "Makefile"
+      ],
+      "matchStrings": [
+        "TRUSTMANAGER_VERSION := (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "cert-manager/trust-manager",
+      "versioningTemplate": "semver"
     }
   ],
   "ignorePaths": []

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -18,13 +18,8 @@ import (
 )
 
 const (
-	certmanagerVersion = "v1.19.1"
-	certmanagerChart   = "oci://quay.io/jetstack/charts/cert-manager"
-
-	trustmanagerChart   = "oci://quay.io/jetstack/charts/trust-manager"
-	trustmanagerVersion = "v0.20.2"
-
-	argoWorkflowsVersion = "v4.0.5"
+	certmanagerChart     = "oci://quay.io/jetstack/charts/cert-manager"
+	trustmanagerChart    = "oci://quay.io/jetstack/charts/trust-manager"
 	argoWorkflowsURLTmpl = "https://github.com/argoproj/argo-workflows/releases/download/%s/quick-start-minimal.yaml"
 
 	minioRepoUrl = "https://charts.min.io"
@@ -59,6 +54,9 @@ var (
 			return "helm"
 		}
 	}()
+	trustmanagerVersion  = getEnvOrExit("TRUSTMANAGER_VERSION")
+	certmanagerVersion   = getEnvOrExit("CERTMANAGER_VERSION")
+	argoWorkflowsVersion = getEnvOrExit("ARGO_WORKFLOWS_VERSION")
 
 	kubeConfigPath = ""
 )
@@ -329,4 +327,13 @@ func orderState(name string, state func(string) bool) bool {
 		}
 	}
 	return true
+}
+
+func getEnvOrExit(name string) string {
+	if v, ok := os.LookupEnv(name); ok {
+		return v
+	}
+	fmt.Fprintf(os.Stderr, "%s was not set\n", name)
+	os.Exit(1)
+	return ""
 }


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Closes #344 

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development and local cluster setup now use configurable component versions for Argo Workflows, cert-manager, and trust-manager.
  * Automation configured to monitor and propose updates for cert-manager and trust-manager versions.
* **Tests**
  * End-to-end test suite now requires these version values via environment variables and fails fast if they are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/artifact-conduit/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->