### PR TITLE
feat: include e2e tests in CI

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -48,6 +48,8 @@ jobs:
       is-local: ${{ env.ACT == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Setup Local Registry for act
         if: ${{ env.ACT == 'true' }}
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,6 +17,14 @@ on:
       - "docs/**"
       - "**/*.md"
     types: [labeled, unlabeled, opened, synchronize, reopened]
+  workflow_call:
+    outputs:
+      image-tag:
+        description: "The commit SHA used as image tag, empty if no images were built"
+        value: ${{ jobs.buildAndPush.outputs.image-tag }}
+      is-local:
+        description: "Whether images were built for local act environment"
+        value: ${{ jobs.buildAndPush.outputs.is-local }}
 
 jobs:
   buildAndPush:
@@ -34,19 +42,31 @@ jobs:
       id-token: write # Needed to create an OIDC token for keyless signing
       attestations: write # Write attestations to GitHub API as well
     name: Build and Publish Docker Image
-    # Condition: Run on push to main, published release, OR PR with 'ok-to-image' label
+    # Condition: Run on push to main, published release, PR with 'ok-to-image' label, or any workflow_call (caller already decided)
     if: |
       github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ok-to-image')) ||
+      (github.event_name == 'pull_request' && (
+        contains(toJSON(github.event.pull_request.labels), '"ok-to-image"') ||
+        contains(toJSON(github.event.pull_request.labels), '"ok-to-e2e"')
+      )) ||
       (github.event_name == 'release' && github.event.action == 'published')
     runs-on: ubuntu-24.04
+    outputs:
+      image-tag: ${{ steps.meta.outputs.version }}
+      is-local: ${{ env.ACT == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Local Registry for act
+        if: ${{ env.ACT == 'true' }}
+        run: |
+          if ! docker ps | grep -q act-registry; then
+            docker run -d -p 5001:5000 --name act-registry registry:2
+          fi
       - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         id: meta
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}
+            ${{ env.ACT == 'true' && 'localhost:5001/local' || format('ghcr.io/{0}', github.repository_owner) }}/${{ matrix.image.name }}
           tags: |
             type=semver,pattern={{version}}
             type=schedule
@@ -57,6 +77,7 @@ jobs:
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' }}
       - name: Set up QEMU
+        if: ${{ env.ACT != 'true' }}
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
         with:
           platforms: arm64
@@ -65,7 +86,9 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:
           version: latest
+          driver-opts: ${{ env.ACT == 'true' && 'network=host' || '' }}
       - name: Login to GHCR
+        if: ${{ env.ACT != 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
@@ -73,11 +96,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: image
-        timeout-minutes: 10
+        timeout-minutes: 20
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.ACT == 'true' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -85,8 +108,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Install cosign
+        if: ${{ env.ACT != 'true' }}
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Sign image with cosign
+        if: ${{ env.ACT != 'true' }}
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
@@ -105,6 +130,7 @@ jobs:
           IFS=$'\n' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
           echo "tag=${TAGS[0]}" >> $GITHUB_OUTPUT
       - name: Generate SBOM
+        if: ${{ env.ACT != 'true' }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ${{ steps.first-tag.outputs.tag }}
@@ -112,6 +138,7 @@ jobs:
           output-file: 'sbom.cyclonedx.json'
           upload-release-assets: false # we use immutable releases
       - name: Attest SBOM
+        if: ${{ env.ACT != 'true' }}
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}
@@ -119,8 +146,20 @@ jobs:
           sbom-path: 'sbom.cyclonedx.json'
           push-to-registry: true
       - name: Attest provenance
+        if: ${{ env.ACT != 'true' }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}
           subject-digest: ${{ steps.image.outputs.digest }}
           push-to-registry: true
+
+  test-e2e:
+    needs: buildAndPush
+    if: needs.buildAndPush.result == 'success'
+    uses: ./.github/workflows/test-e2e.yaml
+    with:
+      image-tag: ${{ needs.buildAndPush.outputs.image-tag }}
+      is-local: ${{ fromJson(needs.buildAndPush.outputs.is-local) }}
+    permissions:
+      contents: read
+      packages: read

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,14 +17,6 @@ on:
       - "docs/**"
       - "**/*.md"
     types: [labeled, unlabeled, opened, synchronize, reopened]
-  workflow_call:
-    outputs:
-      image-tag:
-        description: "The commit SHA used as image tag, empty if no images were built"
-        value: ${{ jobs.buildAndPush.outputs.image-tag }}
-      is-local:
-        description: "Whether images were built for local act environment"
-        value: ${{ jobs.buildAndPush.outputs.is-local }}
 
 jobs:
   buildAndPush:

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,0 +1,53 @@
+name: E2E Tests
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        description: "Docker image tag to test"
+        required: true
+        type: string
+      is-local:
+        description: "running locally with act, which requires using localhost registry instead of GHCR"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  test-e2e:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - id: go-version
+        uses: opendefensecloud/dev-kit/.github/actions/get-go-version@9fe77282c8260284d4efdb69d19b883e52e9a4d8 # v1.0.9
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ steps.go-version.outputs.version }}
+      - name: Create Kubernetes (Kind) Cluster
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        with:
+          cluster_name: arc-test-e2e
+          node_image: kindest/node:v1.33.1
+      - name: Install Tools
+        run: |
+          # Install kubectl
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x ./kubectl
+          sudo mv ./kubectl /usr/local/bin/kubectl
+          kubectl version --client
+
+          # Install helm
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          helm version
+      - name: Run E2E Test Suite
+        env:
+          E2E_IMAGE_SOURCE: ${{ inputs.is-local && 'local' || 'ghcr' }}
+          REGISTRY: ${{ inputs.is-local && 'localhost:5001/local' || format('ghcr.io/{0}', github.repository_owner) }}
+          IMAGE_TAG: ${{ inputs.image-tag }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make test-e2e E2E_IMAGE_SOURCE=$E2E_IMAGE_SOURCE TAG=$IMAGE_TAG REGISTRY=$REGISTRY

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - id: go-version
         uses: opendefensecloud/dev-kit/.github/actions/get-go-version@9fe77282c8260284d4efdb69d19b883e52e9a4d8 # v1.0.9
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/update-action-pins.yml
+++ b/.github/workflows/update-action-pins.yml
@@ -15,7 +15,7 @@ jobs:
           persist-credentials: false
       - name: Verify all actions are pinned to a SHA
         run: |
-          unpinned=$(grep -rE '^\s+(- )?uses: ' .github/workflows/ \
+          unpinned=$(grep -rhE '^\s+(- )?uses: ' .github/workflows/ \
             | grep -vE '^\s+(- )?uses: \.\/' \
             | grep -vE '@[0-9a-f]{40}($|\s)' || true)
           if [[ -n "$unpinned" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,20 @@ test: $(SETUP_ENVTEST) $(GINKGO) ## Run all tests
 manifests: $(CONTROLLER_GEN) ## Generate ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./pkg/controller/...;./api/..." output:rbac:artifacts:config=charts/arc/files
 
-KIND_CLUSTER_E2E ?= arc-test-e2e
+KIND_CLUSTER_E2E  ?= arc-test-e2e
+E2E_IMAGE_SOURCE  ?= local
+REGISTRY          ?= localhost/local
+TAG               ?= e2e
+
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.
 	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_E2E)
 	KIND=$(KIND) \
 	KIND_CLUSTER=$(KIND_CLUSTER_E2E) \
 	HELM=$(HELM) \
+	E2E_IMAGE_SOURCE=$(E2E_IMAGE_SOURCE) \
+	REGISTRY=$(REGISTRY) \
+	IMAGE_TAG=$(TAG) \
 	go test -count=1 -tags=e2e ./test/e2e/ -v -timeout=1h -ginkgo.v -ginkgo.timeout=1h
 	$(MAKE) cleanup-test-e2e
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -100,6 +100,10 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	if imageSource != "local" && ghcrToken == "" {
+		Fail("GHCR_TOKEN must be set when E2E_IMAGE_SOURCE is not \"local\"")
+	}
+
 	// Let's retrieve the kubeconfig of the kind cluster
 	By("fetching the kubeconfig from kind")
 	f, err := os.CreateTemp("", "e2e-kubeconfig")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -100,8 +100,16 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	if imageSource != "local" && ghcrToken == "" {
-		Fail("GHCR_TOKEN must be set when E2E_IMAGE_SOURCE is not \"local\"")
+	if imageSource != "local" {
+		if ghcrToken == "" {
+			Fail("GHCR_TOKEN must be set when E2E_IMAGE_SOURCE is not \"local\"")
+		}
+		if imageRegistry == "" {
+			Fail("REGISTRY must be set when E2E_IMAGE_SOURCE is not \"local\"")
+		}
+		if imageTag == "" {
+			Fail("IMAGE_TAG must be set when E2E_IMAGE_SOURCE is not \"local\"")
+		}
 	}
 
 	// Let's retrieve the kubeconfig of the kind cluster

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,8 +26,12 @@ const (
 
 	zotRepoURL = "https://zotregistry.dev/helm-charts"
 
-	apiserverImage = "apiserver:e2e"
-	managerImage   = "manager:e2e"
+	// Image names used when building from source (local development)
+	localApiserverImage = "apiserver:e2e"
+	localManagerImage   = "manager:e2e"
+
+	// Kubernetes secret name used for GHCR image pull auth
+	ghcrPullSecretName = "ghcr-pull-secret"
 
 	waitTimeout = "5m"
 )
@@ -54,6 +58,30 @@ var (
 			return "helm"
 		}
 	}()
+
+	// imageSource controls where images come from: "local" builds from source, "ghcr" uses pre-built images.
+	imageSource = func() string {
+		if v, ok := os.LookupEnv("E2E_IMAGE_SOURCE"); ok {
+			return v
+		}
+		return "local"
+	}()
+
+	// imageRegistry is the registry prefix, e.g. "ghcr.io/opendefensecloud".
+	imageRegistry = os.Getenv("REGISTRY")
+
+	// imageTag is the tag of the pre-built images (only used when imageSource != "local").
+	imageTag = os.Getenv("IMAGE_TAG")
+
+	// ghcrToken is used to create an imagePullSecret when pulling from GHCR.
+	ghcrToken = os.Getenv("GHCR_TOKEN")
+
+	// Image repository and tag resolved in BeforeSuite; used by e2e_test.go.
+	apiserverImageRepo string
+	apiserverImageTag  string
+	managerImageRepo   string
+	managerImageTag    string
+
 	trustmanagerVersion  = getEnvOrExit("TRUSTMANAGER_VERSION")
 	certmanagerVersion   = getEnvOrExit("CERTMANAGER_VERSION")
 	argoWorkflowsVersion = getEnvOrExit("ARGO_WORKFLOWS_VERSION")
@@ -85,25 +113,35 @@ var _ = BeforeSuite(func() {
 	f.Sync()
 	kubeConfigPath = f.Name()
 
-	// Build images
-	By("building the apiserver image")
-	cmd = exec.Command("make", "docker-build-apiserver", fmt.Sprintf("APISERVER_IMG=%s", apiserverImage))
-	_, err = run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the apiserver image")
+	if imageSource == "local" {
+		By("building the apiserver image")
+		cmd = exec.Command("make", "docker-build-apiserver", fmt.Sprintf("APISERVER_IMG=%s", localApiserverImage))
+		_, err = run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the apiserver image")
 
-	By("building the manager image")
-	cmd = exec.Command("make", "docker-build-manager", fmt.Sprintf("MANAGER_IMG=%s", managerImage))
-	_, err = run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager image")
+		By("building the manager image")
+		cmd = exec.Command("make", "docker-build-manager", fmt.Sprintf("MANAGER_IMG=%s", localManagerImage))
+		_, err = run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager image")
 
-	// Load images
-	By("loading the apiserver image on Kind")
-	err = loadImageToKindClusterWithName(apiserverImage)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the apiserver image into Kind")
+		By("loading the apiserver image on Kind")
+		err = loadImageToKindClusterWithName(localApiserverImage)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the apiserver image into Kind")
 
-	By("loading the manager image on Kind")
-	err = loadImageToKindClusterWithName(managerImage)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
+		By("loading the manager image on Kind")
+		err = loadImageToKindClusterWithName(localManagerImage)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
+
+		apiserverImageRepo = "apiserver"
+		apiserverImageTag = "e2e"
+		managerImageRepo = "manager"
+		managerImageTag = "e2e"
+	} else {
+		apiserverImageRepo = imageRegistry + "/arc-apiserver"
+		apiserverImageTag = imageTag
+		managerImageRepo = imageRegistry + "/arc-controller-manager"
+		managerImageTag = imageTag
+	}
 
 	logf("Installing CertManager...\n")
 	Expect(installCertManager()).To(Succeed(), "Failed to install CertManager")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -41,17 +41,35 @@ var _ = Describe("ARC", Ordered, func() {
 		// _, err = run(cmd)
 		// Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
 
+		if imageSource != "local" && ghcrToken != "" {
+			By("creating GHCR imagePullSecret")
+			cmd = exec.Command("kubectl", "create", "secret", "docker-registry",
+				ghcrPullSecretName,
+				"--namespace", namespace,
+				"--docker-server=ghcr.io",
+				"--docker-username=oauth2",
+				fmt.Sprintf("--docker-password=%s", ghcrToken))
+			_, err = run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create GHCR imagePullSecret")
+		}
+
 		By("deploying apiserver and controller-manager")
 		dir, err := getProjectDir()
 		Expect(err).NotTo(HaveOccurred())
-		cmd = exec.Command(helmBinary, "upgrade", "--install",
+		helmArgs := []string{
+			"upgrade", "--install",
 			"--namespace", namespace, "arc", filepath.Join(dir, "charts", "arc"),
 			"--set", "fullnameOverride=arc",
-			"--set", "apiserver.image.repository=apiserver",
-			"--set", "apiserver.image.tag=e2e",
-			"--set", "controller.image.repository=manager",
-			"--set", "controller.image.tag=e2e",
-			"--set", "apiserver.args.cronMinScheduleInterval=30s")
+			"--set", fmt.Sprintf("apiserver.image.repository=%s", apiserverImageRepo),
+			"--set", fmt.Sprintf("apiserver.image.tag=%s", apiserverImageTag),
+			"--set", fmt.Sprintf("controller.image.repository=%s", managerImageRepo),
+			"--set", fmt.Sprintf("controller.image.tag=%s", managerImageTag),
+			"--set", "apiserver.args.cronMinScheduleInterval=30s",
+		}
+		if imageSource != "local" && ghcrToken != "" {
+			helmArgs = append(helmArgs, "--set", fmt.Sprintf("global.imagePullSecrets[0].name=%s", ghcrPullSecretName))
+		}
+		cmd = exec.Command(helmBinary, helmArgs...)
 		_, err = run(cmd)
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,6 +7,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -49,8 +50,9 @@ var _ = Describe("ARC", Ordered, func() {
 				"--docker-server=ghcr.io",
 				"--docker-username=oauth2",
 				fmt.Sprintf("--docker-password=%s", ghcrToken))
-			_, err = run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create GHCR imagePullSecret")
+			cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeConfigPath))
+			output, err := cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create GHCR imagePullSecret: %s", string(output)))
 		}
 
 		By("deploying apiserver and controller-manager")


### PR DESCRIPTION
## What
Closes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the Docker CI build pipeline with reusable outputs, broader publish/build triggers (including PR labeling), safer gating for non-local runs, and better handling for local development testing via a local registry.
  * Added an end-to-end testing workflow that provisions a Kubernetes cluster and runs tests after successful image builds.
* **New Features**
  * Enhanced e2e tests to support both locally built images and pre-built registry images, with configurable deployment image settings through new Makefile inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->