### PR TITLE
ci: pin dependencies for docs generation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,10 @@
-mkdocs-material
-pymdown-extensions >= 10.16.1
-mkdocs-glightbox
-mkdocs-include-markdown-plugin
-mkdocs-panzoom-plugin
-mkdocs-awesome-nav
+mkdocs-material == 9.7.6
+pymdown-extensions == 10.21.3
+mkdocs-glightbox == 0.5.2
+mkdocs-include-markdown-plugin == 7.3.0
+mkdocs-panzoom-plugin == 0.5.2
+mkdocs-awesome-nav == 3.3.0
 
-pillow >= 10.3.0
-cairosvg
-mike
+pillow == 12.2.0
+cairosvg == 2.9.0
+mike == 2.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,7 @@ mkdocs-awesome-nav == 3.3.0
 pillow == 12.2.0
 cairosvg == 2.9.0
 mike == 2.2.0
+
+# Pinned transitive dependency; introduced to patch GHSA-65pc-fj4g-8rjx
+# (CVE-2026-45409). Kept current by Renovate.
+idna == 3.18


### PR DESCRIPTION
## What
Pins dependencies for dependencies used for docs generation.

## Why
osv sanning failed https://github.com/opendefensecloud/artifact-conduit/actions/runs/27619772724/job/81665092254 with:

```
+-------------------------------------+------+-----------+---------+---------+---------------+-----------------------+
| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE | VERSION | FIXED VERSION | SOURCE                |
+-------------------------------------+------+-----------+---------+---------+---------------+-----------------------+
| https://osv.dev/GHSA-65pc-fj4g-8rjx | 6.9  | PyPI      | idna    | 3.9.0   | 3.15          | docs/requirements.txt |
+-------------------------------------+------+-----------+---------+---------+---------------+-----------------------+
```

Pinned the dependencies so that we control the tooling that we use in CI and pinned a vulnerable, transitive dependency to make the osv scanning happy.

## Testing
none, beside checks in this PR


## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned documentation and tooling dependencies to specific versions for improved reproducibility and stability.
  * Addressed a security vulnerability in project dependencies.
  * Dependencies are now managed automatically to stay current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->