### PR TITLE
ci(release): sign release binaries and checksums with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write # for keyless cosign sign-blob
+  attestations: write # for build-provenance attestation
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Extract go version from flake.nix
+        id: get-go-version
+        run: |
+          GO_VERSION="$(sed -nE 's/^[[:space:]]*goVersion[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)";[[:space:]]*$/\1/p' flake.nix)"
+          if [ "$(printf '%s\n' "$GO_VERSION" | sed '/^$/d' | wc -l)" -ne 1 ]; then
+            echo "::error::Expected exactly one goVersion assignment in flake.nix"
+            exit 1
+          fi
+          echo "version=$GO_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ steps.get-go-version.outputs.version }}
+          cache: true
+
+      - name: Run tests
+        run: make test
+
+      - name: Build binaries
+        run: |
+          for os in linux darwin; do
+            for arch in amd64 arm64; do
+              for cmd in arc-apiserver arc-controller-manager; do
+                CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+                  go build -ldflags="-s -w" \
+                  -o "bin/${cmd}-${os}-${arch}" "./cmd/${cmd}"
+              done
+            done
+          done
+
+      - name: Create checksums
+        run: |
+          find bin -type f ! -name checksums.txt | sort | xargs sha256sum > bin/checksums.txt
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: 'bin/arc-*-*' # binaries only; runs before signing so .sig/.pem are not yet present
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign release artefacts (keyless)
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cd bin
+          for f in *; do
+            [ -f "$f" ] || continue
+            case "$f" in *.sig|*.pem) continue ;; esac
+            cosign sign-blob --yes \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "$f"
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        with:
+          # Release notes are curated by release-drafter; only attach the signed
+          # assets here so the drafted notes are preserved.
+          files: |
+            bin/*
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
   id-token: write # for keyless cosign sign-blob
   attestations: write # for build-provenance attestation
 
@@ -36,7 +35,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ steps.get-go-version.outputs.version }}
-          cache: true
+          cache: false # privileged signing job: avoid shared cache (cache-poisoning)
 
       - name: Run tests
         run: make test

--- a/docs/operator-manual/releases.md
+++ b/docs/operator-manual/releases.md
@@ -5,3 +5,26 @@ You can find the most recent version in the [GitHub Releases](https://github.com
 ## Versioning
 
 Versions are expressed as `x.y.z`, where `x` is the major version, `y` is the minor version, and `z` is the patch version, following Semantic Versioning terminology.
+
+## Verifying release artefacts
+
+Every release artefact (each binary and `checksums.txt`) is keylessly signed with [cosign](https://docs.sigstore.dev/) during the release workflow. For each artefact `<file>`, a matching `<file>.sig` (signature) and `<file>.pem` (certificate) is published next to it on the GitHub Release page.
+
+To verify a downloaded binary, install [cosign](https://docs.sigstore.dev/system_config/installation/) and run `cosign verify-blob`, pointing it at the artefact's `.pem` and `.sig`:
+
+```bash
+cosign verify-blob \
+  --certificate arc-apiserver-linux-amd64.pem \
+  --signature  arc-apiserver-linux-amd64.sig \
+  --certificate-identity-regexp 'https://github.com/opendefensecloud/artifact-conduit/\.github/workflows/release\.yaml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  arc-apiserver-linux-amd64
+```
+
+The same command works for `checksums.txt` and any other artefact — swap the file names accordingly. A successful run prints `Verified OK`.
+
+Release binaries additionally carry a [build-provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), which can be verified with the GitHub CLI:
+
+```bash
+gh attestation verify arc-apiserver-linux-amd64 --repo opendefensecloud/artifact-conduit
+```


### PR DESCRIPTION
## What
Keylessly sign every GitHub Release binary (and `checksums.txt`) with cosign, attach build-provenance attestations, and document how to verify them.

Part of https://github.com/opendefensecloud/odd-internal/issues/42

## Why
OpenSSF Scorecard `Signed-Releases` has no signed assets to find on this repo: container images (`docker.yaml`) and Helm charts (`helm-publish.yaml`) are already keyless cosign-signed, but no standalone binaries were published as Release assets at all. This adds the missing signed-binary distribution channel — a tag-triggered `release.yaml` that cross-compiles the binaries and signs them — reusing the proven keyless pattern (and the same cosign pin) from `docker.yaml`.

## Testing
- `release.yaml` parses as valid YAML.
- Smoke-tested a cross-compile locally (`CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" ./cmd/arc-apiserver`) — builds clean.
- End-to-end (post-merge): push a `vX.Y.Z-rc1` pre-release tag, confirm a matching `.sig`/`.pem` for every asset on the Release page, run the documented `cosign verify-blob`, then confirm Scorecard `Signed-Releases` lifts after the next real tag.

## Notes for reviewers
- New workflow `release.yaml` builds `arc-apiserver` and `arc-controller-manager` for linux/darwin × amd64/arm64, generates `checksums.txt`, attests build provenance, cosign-signs each artefact, and uploads `bin/*` to the Release.
- Adds `id-token: write` (keyless OIDC) and `attestations: write` to the release job — required for `cosign sign-blob` and `actions/attest-build-provenance`.
- The `.sig`/`.pem` files upload automatically via the existing `files: bin/*` glob; signing runs after checksum creation so `checksums.txt` is itself signed. Provenance is attested before signing so `.sig`/`.pem` are not part of the attested subject set.
- Uses `-ldflags="-s -w"` to match this repo's `Dockerfile` (the binaries declare no `main.version` vars to inject).
- Release notes stay owned by `release-drafter`: `generate_release_notes` is intentionally omitted so the step only attaches signed assets to the tag's release rather than regenerating notes.
- Image building stays solely in `docker.yaml`; `release.yaml` deliberately contains no image-build job, so there is no duplicate build on the shared `v*` tag trigger.
- `cosign` is pinned to the same digest already used in `docker.yaml`. Verification (`cosign verify-blob` and `gh attestation verify`) is documented in `docs/operator-manual/releases.md`.

## Checklist
- [x] ~~Tests added/updated~~ n/a (CI workflow + docs)
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section to the operator manual explaining how to verify release artifacts, including `checksums.txt` and build-provenance attestations.

* **Chores**
  * Updated the automated release pipeline to build and cross-compile binaries for multiple OS/architectures, generate `checksums.txt`, and keylessly sign release artifacts (including publishing matching signature/verification files) and provenance attestations.
  * Releases are marked as prereleases when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->