### PR TITLE
ci: preserve Go build cache between Docker workflow runs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -79,6 +79,7 @@ jobs:
         with:
           platforms: arm64
       - name: Set up Docker Buildx
+        id: buildx
         timeout-minutes: 5
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:
@@ -91,6 +92,37 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # buildkit-cache-dance restores/saves the RUN --mount=type=cache contents
+      # (the Go build + module caches in our Dockerfile). docker/build-push-action's
+      # cache-to=gha preserves layers but NOT cache-mount contents, so without
+      # this dance every CI build starts with an empty Go build cache.
+      # Per-binary scope; go.sum + sha in the key so a `go.sum` bump invalidates
+      # cleanly but consecutive pushes can incrementally refresh the cache.
+      - name: Cache Go build mounts
+        if: ${{ env.ACT != 'true' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: go-cache
+        with:
+          path: cache-mount
+          # Scope key by trust level so PR builds and trusted (push to main /
+          # release) builds live in disjoint cache namespaces. Prevents a
+          # malicious PR from poisoning a cache that a later trusted build
+          # would consume via the restore-keys ladder. Flagged by zizmor
+          # (cache-poisoning) and CodeRabbit.
+          key: cache-mount-${{ matrix.image.name }}-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            cache-mount-${{ matrix.image.name }}-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-
+            cache-mount-${{ matrix.image.name }}-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-
+      - name: Inject Go build cache into buildx
+        if: ${{ env.ACT != 'true' }}
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: cache-mount
+          dockerfile: Dockerfile
+          # Always extract so post-build mount contents are saved for the next
+          # run, even when we restored from a partial-key match.
+          skip-extraction: false
       - name: Build and push
         id: image
         timeout-minutes: 20
@@ -102,8 +134,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ matrix.image.target }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Same trust-scoping rationale as the actions/cache step above: keep
+          # PR-built layer caches out of the trusted (push/release) scope.
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}
       - name: Install cosign
         if: ${{ env.ACT != 'true' }}
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -160,3 +194,4 @@ jobs:
     permissions:
       contents: read
       packages: read
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,18 @@
 FROM --platform=$BUILDPLATFORM golang:1.26@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS builder
 
 WORKDIR /workspace
-RUN go env -w GOMODCACHE=/root/.cache/go-build
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
 
 # Cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/root/.cache/go-build go mod download
+# and so that source changes don't invalidate our downloaded layer. Modules live at the
+# default $GOMODCACHE (/go/pkg/mod); the build cache is /root/.cache/go-build. Both mounts
+# are restored from actions/cache via the cache-mount preservation step in docker.yaml so
+# the CI cold-start doesn't repeat a full Go compile every run.
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy the go source
 COPY api/ api/
@@ -26,13 +29,13 @@ RUN mkdir bin
 
 FROM builder AS apiserver-builder
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
+    --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" ${GO_BUILD_FLAGS} -o bin/arc-apiserver ./cmd/arc-apiserver
 
 
 FROM builder AS manager-builder
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
+    --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" ${GO_BUILD_FLAGS} -o bin/arc-controller-manager ./cmd/arc-controller-manager
 
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
## What

Part of [#237](https://github.com/opendefensecloud/solution-arsenal/issues/237).

## Testing
Tested by multiple runs.

## Checklist
- [-] Tests added/updated
- [X] No breaking changes (or upgrade path documented above)
- [X] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Go build caching in Docker workflow for improved build performance and reduced build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->