### PR TITLE
chore: improve envtest/kind handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ ENVTEST_K8S_VERSION ?= 1.36.0
 # directly to decouple them.
 KIND_NODE_IMAGE ?= kindest/node:v$(patsubst v%,%,$(ENVTEST_K8S_VERSION))
 
+# The image tag (e.g. v1.36.0) the cluster's K8s server version must match.
+# Derived from KIND_NODE_IMAGE itself so overriding the image keeps the check
+# honest. Splitting on ':' takes the tag even with a registry:port prefix.
+KIND_NODE_VERSION := $(lastword $(subst :, ,$(KIND_NODE_IMAGE)))
+
 export ARGO_WORKFLOWS_VERSION := $(shell awk '/^[ \t]+github.com\/argoproj\/argo-workflows/ {print $$2}' go.mod)
 export CERTMANAGER_VERSION := v1.20.2
 export TRUSTMANAGER_VERSION := v0.22.1
@@ -80,13 +85,21 @@ kind-cluster: ## Create the Kind cluster $(KIND_CLUSTER) pinned to KIND_NODE_IMA
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
 	}
-	@case "$$($(KIND) get clusters)" in \
-		*"$(KIND_CLUSTER)"*) \
-			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
-		*) \
-			echo "Creating Kind cluster '$(KIND_CLUSTER)' ($(KIND_NODE_IMAGE))..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) --image $(KIND_NODE_IMAGE) ;; \
-	esac
+	@if $(KIND) get clusters 2>/dev/null | grep -qx "$(KIND_CLUSTER)"; then \
+		current=$$($(KUBECTL) --context kind-$(KIND_CLUSTER) version -o json 2>/dev/null \
+			| $(JQ) -r '.serverVersion.gitVersion // empty' 2>/dev/null) || true; \
+		case "$$current" in \
+			$(KIND_NODE_VERSION) | $(KIND_NODE_VERSION)[-+]*) \
+				echo "Kind cluster '$(KIND_CLUSTER)' already exists at $$current. Skipping creation." ;; \
+			*) \
+				echo "error: Kind cluster '$(KIND_CLUSTER)' runs '$${current:-unknown}', but $(KIND_NODE_VERSION) is required (KIND_NODE_IMAGE=$(KIND_NODE_IMAGE))." >&2; \
+				echo "       Recreate it: $(KIND) delete cluster --name $(KIND_CLUSTER) && $(MAKE) kind-cluster KIND_CLUSTER=$(KIND_CLUSTER)" >&2; \
+				exit 1 ;; \
+		esac; \
+	else \
+		echo "Creating Kind cluster '$(KIND_CLUSTER)' ($(KIND_NODE_IMAGE))..."; \
+		$(KIND) create cluster --name $(KIND_CLUSTER) --image $(KIND_NODE_IMAGE); \
+	fi
 
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ DOCS_IMG ?= arc-docs:latest
 
 ENVTEST_K8S_VERSION ?= 1.36.0
 
+# Kind node image for local/e2e clusters — defaults to track ENVTEST_K8S_VERSION
+# so envtest (`make test`) and Kind-based clusters (`make dev-cluster`,
+# `make test-e2e`) target the same K8s release. Override KIND_NODE_IMAGE
+# directly to decouple them.
+KIND_NODE_IMAGE ?= kindest/node:v$(patsubst v%,%,$(ENVTEST_K8S_VERSION))
+
 export ARGO_WORKFLOWS_VERSION := $(shell awk '/^[ \t]+github.com\/argoproj\/argo-workflows/ {print $$2}' go.mod)
 export CERTMANAGER_VERSION := v1.20.2
 export TRUSTMANAGER_VERSION := v0.22.1
@@ -47,9 +53,14 @@ lint: lint-no-golangci golangci-lint ## Run linters
 lint-no-golangci: $(ADDLICENSE) shellcheck  ## Run linters but not golangci-lint to exit early in CI/CD pipeline
 	$(MAKE) addlicense-check license=apache comment='$(LICENSE_COMMENT)' pattern='*\.go'
 
+.PHONY: envtest-binaries-sideload
+envtest-binaries-sideload: $(SETUP_ENVTEST) ## Populate the envtest cache for ENVTEST_K8S_VERSION from upstream K8s/etcd releases when controller-tools hasn't packaged it
+	@SETUP_ENVTEST=$(SETUP_ENVTEST) BIN_DIR=$(LOCALBIN) YQ=$(YQ) \
+		bash hack/envtest-sideload.sh $(ENVTEST_K8S_VERSION)
+
 .PHONY: test
-test: $(SETUP_ENVTEST) $(GINKGO) ## Run all tests
-	@KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=arc.full.coverprofile $(testargs)
+test: $(SETUP_ENVTEST) $(GINKGO) envtest-binaries-sideload ## Run all tests
+	@KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -i -p path)" $(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=arc.full.coverprofile $(testargs)
 	@cat arc.full.coverprofile | grep -v /arc/api > arc.coverprofile
 
 .PHONY: manifests
@@ -61,9 +72,25 @@ E2E_IMAGE_SOURCE  ?= local
 REGISTRY          ?= localhost/local
 TAG               ?= e2e
 
+# Like common.mk's setup-local-cluster, but pins the node image to
+# KIND_NODE_IMAGE so Kind clusters track the same K8s release as envtest.
+.PHONY: kind-cluster
+kind-cluster: ## Create the Kind cluster $(KIND_CLUSTER) pinned to KIND_NODE_IMAGE if it does not exist
+	@command -v $(KIND) >/dev/null 2>&1 || { \
+		echo "Kind is not installed. Please install Kind manually."; \
+		exit 1; \
+	}
+	@case "$$($(KIND) get clusters)" in \
+		*"$(KIND_CLUSTER)"*) \
+			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
+		*) \
+			echo "Creating Kind cluster '$(KIND_CLUSTER)' ($(KIND_NODE_IMAGE))..."; \
+			$(KIND) create cluster --name $(KIND_CLUSTER) --image $(KIND_NODE_IMAGE) ;; \
+	esac
+
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.
-	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_E2E)
+	$(MAKE) kind-cluster KIND_CLUSTER=$(KIND_CLUSTER_E2E)
 	KIND=$(KIND) \
 	KIND_CLUSTER=$(KIND_CLUSTER_E2E) \
 	HELM=$(HELM) \
@@ -82,7 +109,7 @@ KIND_CLUSTER_DEV ?= arc-dev
 
 .PHONY: dev-cluster
 dev-cluster: manifests ## Install all necessary components into local Kind cluster for local development
-	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_DEV)
+	$(MAKE) kind-cluster KIND_CLUSTER=$(KIND_CLUSTER_DEV)
 	@echo -e "\nSETTING UP CERT-MANAGER:\n"
 	$(KUBECTL) apply --context kind-$(KIND_CLUSTER_DEV) -f \
 		https://github.com/cert-manager/cert-manager/releases/download/$(CERTMANAGER_VERSION)/cert-manager.yaml

--- a/hack/envtest-sideload.sh
+++ b/hack/envtest-sideload.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+# Sideload envtest binaries from canonical upstream sources (dl.k8s.io and
+# etcd-io GitHub releases) for K8s versions that controller-tools hasn't
+# packaged into its envtest-releases index yet. envtest's release cadence
+# lags K8s releases sporadically, so a freshly-pinned ENVTEST_K8S_VERSION may
+# not be downloadable via `setup-envtest use` until controller-tools catches
+# up. This populates setup-envtest's cache directly from upstream instead.
+#
+# dl.k8s.io has all versions but only Linux builds. controller-tools has
+# Darwin builds, but not for all versions of Kubernetes and etcd, so running
+# a specific version under Darwin might not be possible.
+#
+# So it should:
+# - check K8S_VERSION, use setup-envtest binaries if already cached
+# - if not, fall back to dl.k8s.io (which has no Darwin builds) on Linux,
+#   or defer to `setup-envtest use` on non-Linux hosts
+#
+# Idempotent — exits 0 immediately if setup-envtest already has the version
+# cached, so this is safe as a `test` prerequisite that runs every invocation.
+#
+# Required env / args:
+#   $1            K8s version (e.g. 1.36.0)
+#   SETUP_ENVTEST path to setup-envtest binary
+#   BIN_DIR       cache directory (matches the Makefile's $(LOCALBIN))
+#
+# Optional env:
+#   YQ            path to yq (defaults to `yq` on PATH)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+K8S_VERSION="${1:?Usage: $0 <k8s-version>}"
+
+# Accept either "1.32.1" or "v1.32.1" — strip an optional leading "v" so
+# URL construction (which adds its own "v") doesn't end up with "vv1.32.1".
+K8S_VERSION="${K8S_VERSION#v}"
+
+: "${SETUP_ENVTEST:?SETUP_ENVTEST must be set}"
+: "${BIN_DIR:?BIN_DIR must be set}"
+
+YQ="${YQ:-yq}"
+
+# Idempotency — bail out if setup-envtest already finds this version in cache.
+if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -i -p path >/dev/null 2>&1; then
+	exit 0
+fi
+
+# Detect host. dl.k8s.io publishes kube-apiserver only for linux server
+# platforms (darwin/windows return 404). controller-tools cross-compiles its
+# own darwin/windows envtest archives from K8s source — we can't replicate
+# that from a shell script, so on non-linux hosts we defer to vanilla
+# `setup-envtest use` (which downloads from controller-tools' index). It
+# succeeds whenever the requested version is in the index; only when the
+# index has no entry do we have to give up and ask the dev to pin.
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+if [ "$os" != "linux" ]; then
+	if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -p path >/dev/null 2>&1; then
+		exit 0
+	fi
+
+	cat >&2 <<EOF
+envtest-sideload: ${os} is supported via controller-tools' pre-packaged
+archives, but '${K8S_VERSION}' is not in their index and dl.k8s.io has
+no kube-apiserver binary for non-linux platforms.
+
+List available versions: ${SETUP_ENVTEST} list
+
+Then pin ENVTEST_K8S_VERSION to one of those, or run on Linux where
+this script can sideload the upstream K8s/etcd binaries directly.
+EOF
+	exit 1
+fi
+
+case "$(uname -m)" in
+	x86_64) arch=amd64 ;;
+	aarch64 | arm64) arch=arm64 ;;
+	*) echo "envtest-sideload: unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Wrap curl with retries + timeouts so transient network blips don't fail
+# the whole sideload. --retry-all-errors covers HTTP 5xx (curl 7.71+, 2020).
+# --max-time bounds a single request; bytes are ~150 MB max (kube-apiserver),
+# 300 s is plenty even on slow runners.
+fetch() {
+	curl --fail --silent --show-error --location \
+		--retry 3 --retry-delay 2 --retry-all-errors \
+		--connect-timeout 10 --max-time 300 "$@"
+}
+
+# Look up the etcd version K8s ships with from its build/dependencies.yaml.
+# Self-updating per K8s release.
+deps_url="https://raw.githubusercontent.com/kubernetes/kubernetes/v${K8S_VERSION}/build/dependencies.yaml"
+
+etcd_version=$(fetch "$deps_url" \
+	| "$YQ" '.dependencies[] | select(.name == "etcd") | .version')
+
+if [[ -z "$etcd_version" ]]; then
+	echo "envtest-sideload: could not resolve etcd version from $deps_url" >&2
+	exit 1
+fi
+
+echo "envtest-sideload: K8s ${K8S_VERSION} ships with etcd ${etcd_version} (${os}/${arch})"
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+
+# --- K8s binaries (kube-apiserver, kubectl) --------------------------------
+#
+# Direct per-binary downloads avoid pulling the ~600 MB server tarball when we
+# only need two binaries (~150 MB + ~50 MB combined).
+#
+# NOTE: If a future K8s release ships a new server binary that envtest
+# expects, envtest will fail to start the control plane and the test run will
+# surface the missing binary. Add the new name to the loop below — the server
+# tarball at dl.k8s.io/v${VER}/kubernetes-server-${os}-${arch}.tar.gz is the
+# canonical index of what's available per release if you need to discover the
+# exact filename.
+k8s_base="https://dl.k8s.io/release/v${K8S_VERSION}/bin/${os}/${arch}"
+
+mkdir -p "$stage/k8s-bin"
+
+for bin in kube-apiserver kubectl; do
+	echo "envtest-sideload: downloading ${k8s_base}/${bin}"
+	fetch -o "$stage/k8s-bin/$bin" "$k8s_base/$bin"
+	fetch -o "$stage/k8s-bin/$bin.sha256" "$k8s_base/$bin.sha256"
+
+	# The .sha256 sibling is just the hex digest; pair with the filename ourselves.
+	(cd "$stage/k8s-bin" && printf '%s %s\n' "$(cat "$bin.sha256")" "$bin" | sha256sum -c -)
+
+	chmod +x "$stage/k8s-bin/$bin"
+done
+
+# --- etcd tarball (etcd binary) --------------------------------------------
+
+etcd_dir="etcd-v${etcd_version}-${os}-${arch}"
+etcd_tar="${etcd_dir}.tar.gz"
+etcd_base="https://github.com/etcd-io/etcd/releases/download/v${etcd_version}"
+
+echo "envtest-sideload: downloading ${etcd_base}/${etcd_tar}"
+
+fetch -o "$stage/$etcd_tar" "$etcd_base/$etcd_tar"
+fetch -o "$stage/SHA256SUMS" "$etcd_base/SHA256SUMS"
+
+# etcd's SHA256SUMS lists `<hash> <filename>` for every platform tarball;
+# grep our specific filename and pass to sha256sum -c.
+(cd "$stage" && grep " ${etcd_tar}$" SHA256SUMS | sha256sum -c -)
+
+tar -C "$stage" -xzf "$stage/$etcd_tar" "$etcd_dir/etcd"
+
+# --- Assemble the sideload tarball with the three binaries at top level ---
+
+sideload_tar="$stage/sideload.tar.gz"
+
+tar -czf "$sideload_tar" \
+	-C "$stage/k8s-bin" kube-apiserver kubectl \
+	-C "$stage/$etcd_dir" etcd
+
+# Feed it to setup-envtest. --os/--arch matter — sideload writes the cache
+# entry keyed on platform.
+echo "envtest-sideload: sideloading ${K8S_VERSION} into ${BIN_DIR}"
+
+"$SETUP_ENVTEST" sideload "$K8S_VERSION" \
+	--os "$os" --arch "$arch" --bin-dir "$BIN_DIR" \
+	< "$sideload_tar"
+
+# Sanity-check that setup-envtest can now find it.
+"$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -i -p path >/dev/null
+
+echo "envtest-sideload: done"


### PR DESCRIPTION
## What

[Not all K8s versions are supported by envtest](https://github.com/kubernetes-sigs/controller-tools/issues/1320), download from `dl.k8s.io` directly, if possible.

Aligning with https://github.com/opendefensecloud/solution-arsenal/pull/610

## Testing
Manual against some K8s versions.

E2E tests can be run like `make test-e2e ENVTEST_K8S_VERSION=1.33.0` against any version, Kind and K8s binaries will match.

## Checklist
- [ ] ~~Tests added/updated~~ n/a
- [X] No breaking changes (or upgrade path documented above)
- [X] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic fallback to sideload missing `envtest` Kubernetes binaries when they aren’t cached.
  * Introduced a dedicated Kind cluster setup flow that reuses an existing cluster when its Kubernetes version matches the expected one.

* **Bug Fixes**
  * Improved alignment between Kind/E2E Kubernetes server version and the `envtest` version to reduce test inconsistencies.
  * Updated E2E and dev cluster commands to use the new Kind cluster workflow and asset resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->