### PR TITLE
fix: strip any sub-paths for registries in ocmconfig

### DIFF
--- a/examples/ocm/cluster-workflow-template.yaml
+++ b/examples/ocm/cluster-workflow-template.yaml
@@ -120,7 +120,7 @@ spec:
               consumers:
                 - identity:
                     type: OCIRegistry
-                    hostname: $(echo '{{workflow.parameters.srcRemoteURL}}' | cut -d : -f 1)
+                    hostname: $(echo '{{workflow.parameters.srcRemoteURL}}' | cut -d / -f 1 | cut -d : -f 1)
                   credentials:
                     - type: Credentials
                       properties:
@@ -205,7 +205,7 @@ spec:
               consumers:
                 - identity:
                     type: OCIRegistry
-                    hostname: $(echo '{{workflow.parameters.dstRemoteURL}}' | cut -d : -f 1)
+                    hostname: $(echo '{{workflow.parameters.dstRemoteURL}}' | cut -d / -f 1 | cut -d : -f 1)
                   credentials:
                     - type: Credentials
                       properties:


### PR DESCRIPTION
## What

Handling registries like `example.com/my-repo`. OCM expects credentials to be configured for just `example.com`. We did not strip any possible subpaths prior to this change.

## Checklist
- [x] ~Tests added/updated~
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected registry hostname handling in the OCM cluster workflow template for source and destination container registries.
  * Ensured URL paths are removed before port information is processed, helping credentials configuration target the proper registry locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->