### PR TITLE
fix(release): sign release artefacts as Sigstore bundles

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
-          subject-path: 'bin/arc-*-*' # binaries only; runs before signing so .sig/.pem are not yet present
+          subject-path: 'bin/arc-*-*' # binaries only; runs before signing so the .sigstore.json bundles are not yet present
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -71,10 +71,15 @@ jobs:
           cd bin
           for f in *; do
             [ -f "$f" ] || continue
-            case "$f" in *.sig|*.pem) continue ;; esac
+            case "$f" in *.sigstore.json) continue ;; esac
+            # Emit a Sigstore bundle (signature + cert + Rekor proof), named
+            # *.sigstore.json so OpenSSF Scorecard's Signed-Releases check
+            # detects it. Don't revert to --output-signature/--output-certificate:
+            # those are deprecated and silently ignored by newer cosign, which
+            # defaults to the bundle format and requires --bundle.
             cosign sign-blob --yes \
-              --output-signature "${f}.sig" \
-              --output-certificate "${f}.pem" \
+              --new-bundle-format=true \
+              --bundle "${f}.sigstore.json" \
               "$f"
           done
 

--- a/docs/operator-manual/releases.md
+++ b/docs/operator-manual/releases.md
@@ -8,14 +8,13 @@ Versions are expressed as `x.y.z`, where `x` is the major version, `y` is the mi
 
 ## Verifying release artefacts
 
-Every release artefact (each binary and `checksums.txt`) is keylessly signed with [cosign](https://docs.sigstore.dev/) during the release workflow. For each artefact `<file>`, a matching `<file>.sig` (signature) and `<file>.pem` (certificate) is published next to it on the GitHub Release page.
+Every release artefact (each binary and `checksums.txt`) is keylessly signed with [cosign](https://docs.sigstore.dev/) during the release workflow. For each artefact `<file>`, a matching Sigstore bundle `<file>.sigstore.json` (containing the signature, certificate, and transparency-log proof) is published next to it on the GitHub Release page.
 
-To verify a downloaded binary, install [cosign](https://docs.sigstore.dev/system_config/installation/) and run `cosign verify-blob`, pointing it at the artefact's `.pem` and `.sig`:
+To verify a downloaded binary, install [cosign](https://docs.sigstore.dev/system_config/installation/) and run `cosign verify-blob`, pointing it at the artefact's `.sigstore.json` bundle:
 
 ```bash
 cosign verify-blob \
-  --certificate arc-apiserver-linux-amd64.pem \
-  --signature  arc-apiserver-linux-amd64.sig \
+  --bundle arc-apiserver-linux-amd64.sigstore.json \
   --certificate-identity-regexp 'https://github.com/opendefensecloud/artifact-conduit/\.github/workflows/release\.yaml@.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   arc-apiserver-linux-amd64


### PR DESCRIPTION
## What
Relates to #405 (signed releases)

Sign release artefacts as Sigstore bundles (`<file>.sigstore.json`) instead of separate `.sig`/`.pem` files, fixing the release signing step shipped in #405.

## Why
cosign's `--output-signature`/`--output-certificate` flags are deprecated and are silently ignored by newer cosign, which defaults to the bundle format and requires `--bundle`. With no `--bundle` set the step fails (`create bundle file: open : no such file or directory`), so the first release tag would die at signing with no assets attached. Emit a modern Sigstore bundle per artefact instead; OpenSSF Scorecard's `Signed-Releases` check recognises the `.sigstore.json` extension, so the score still lifts.

## Testing
The identical fix was just proven end-to-end in the sibling `solution-arsenal` repo: tag `v0.3.0-rc2` ran the release workflow to success (the signing step that previously failed now passes), published 34 assets (17 artefacts + a matching `.sigstore.json` bundle each), and a downloaded binary verified against its bundle with `cosign verify-blob --bundle … --certificate-identity-regexp … --certificate-oidc-issuer …` → `Verified OK`. `.sigstore.json` is confirmed present in Scorecard's `signatureExtensions`. The binary signing path only runs on a `v*` tag, so it is first exercised here on the next release tag.

## Notes for reviewers
CI + docs only (`.github/workflows/release.yaml`, `docs/operator-manual/releases.md`); no code, API, or generated artefacts touched. Artefact naming changes from `<file>.sig` + `<file>.pem` to a single `<file>.sigstore.json` bundle; the documented `cosign verify-blob` command is updated to match.

## Checklist
- [x] Tests added/updated — n/a (workflow-only; first exercised on the next release tag)
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release artifacts are now signed and verified using Sigstore bundle files, improving consistency across downloads.
  * Verification instructions were updated to match the new release artifact format, including checksums.

* **Documentation**
  * Updated release verification guidance to use the new bundle-based `cosign` workflow for release files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->