### PR TITLE
ci(release): create the GitHub release as a draft for immutable releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,4 +90,8 @@ jobs:
           # assets here so the drafted notes are preserved.
           files: |
             bin/*
+          # Immutable releases forbid uploading assets to an already-published
+          # release, so create a draft with the signed artefacts attached and
+          # publish it separately (UI, or `gh release edit <tag> --draft=false`).
+          draft: true
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}


### PR DESCRIPTION
## What
Create the GitHub release as a draft so the signed assets attach before publish, fixing release creation on this immutable-releases repository.

## Why
This repo has immutable releases enabled. `action-gh-release` defaulted to `draft: false`, so it published the release immediately and then tried to upload the cosign `.sigstore.json` bundles — which immutable releases forbid on an already-published release. The result: `v0.3.0-rc0` published with zero assets and the workflow failed at `Create GitHub Release`. Setting `draft: true` attaches the signed artefacts to a draft; publishing the draft then locks it immutably with the assets already in place (GitHub's recommended flow for immutable releases).

## Testing
CI-only change; signing itself already passes (the `.sigstore.json` bundles are produced). Confirmed the failure mode on the `v0.3.0-rc0` run (`Create GitHub Release` failed with "Cannot upload asset ...sigstore.json to an immutable release"). After merge, cutting `v0.3.0-rc1` will produce a draft release carrying the bundles, which is then published with `gh release edit v0.3.0-rc1 --draft=false`.

## Notes for reviewers
Behavior change: releases now land as drafts and must be published explicitly (`gh release edit <tag> --draft=false`, or the Releases UI). This is required by immutable releases — assets cannot be added after publish. Mirrors the same fix on `solution-arsenal`; can be automated later with a downstream publish job if desired.

## Checklist
- [x] Tests added/updated — n/a (workflow-only)
- [x] No breaking changes (release flow now needs an explicit publish step — documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release creation now starts as a draft instead of publishing immediately, improving compatibility with immutable release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->