### PR TITLE
test(e2e): use podinfo as clean helm scan fixture

### DIFF
--- a/examples/helm/artifact-type.yaml
+++ b/examples/helm/artifact-type.yaml
@@ -11,6 +11,6 @@ spec:
       - oci
   parameters:
     - name: scanSeverity
-      value: CRITICAL # NOTE only CRITICAL as the helm hello-world example contains HIGH vulnerabilities
+      value: CRITICAL # NOTE only CRITICAL as the podinfo e2e fixture contains HIGH findings (pod-hardening)
   workflowTemplateRef: # argo.Workflow
     name: helm-chart-pipeline

--- a/test/fixtures/helm-order.yaml
+++ b/test/fixtures/helm-order.yaml
@@ -1,10 +1,10 @@
 apiVersion: arc.opendefense.cloud/v1alpha1
 kind: Endpoint
 metadata:
-  name: quay
+  name: ghcr
 spec:
   type: oci
-  remoteURL: quay.io
+  remoteURL: ghcr.io
   usage: PullOnly
 ---
 apiVersion: arc.opendefense.cloud/v1alpha1
@@ -25,12 +25,12 @@ metadata:
 spec:
   defaults:
     srcRef:
-      name: quay
+      name: ghcr
     dstRef:
       name: internal
   artifacts:
     - type: helm
       spec:
-        repo: jetstack/charts
-        chart: cert-manager
-        version: v1.19.1
+        repo: stefanprodan/charts
+        chart: podinfo
+        version: 6.9.2


### PR DESCRIPTION
## What

Swap the helm order e2e fixture from cert-manager to podinfo so the happy-path test scans a genuinely clean artifact.

Closes #416 

## Why

The `helm` e2e pulled `jetstack/charts/cert-manager` and asserted its `trivy config --severity CRITICAL` scan passes. trivy 0.71 reclassified two RBAC checks — `KSV-0041` (manage secrets) and `KSV-0114` (manage webhookconfigurations) — to CRITICAL, which cert-manager legitimately trips. So the test was asserting that an over-privileged chart sails through the security gate, and the trivy 0.70.0 → 0.71.2 bump in #414 turned that latent assumption into a red build.

## Testing

Reproduced locally against the exact chart: `aquasec/trivy:0.70.0 config --severity CRITICAL` exits 0, `0.71.2` exits 1 on the two findings above. Verified `stefanprodan/charts/podinfo` 6.9.2 exits 0 under `trivy:0.71.2 config --severity CRITICAL`. `make codegen` produced no changes.

## Notes for reviewers

The scan workflow template is unchanged — the gate is not weakened, we only point the happy path at a clean artifact instead of masking a real finding. podinfo still has HIGH findings (`KSV-0014`, `KSV-0118`, pod-hardening) which sit below the CRITICAL gate. This fixture fix is independent of the bump and unblocks the trivy update in #414 once rebased.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Helm example note to better match the current fixture and clarify why `CRITICAL` is the expected severity.
* **Chores**
  * Refreshed Helm test data to use a different OCI source and chart example, keeping the fixture aligned with current test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->