### PR TITLE
chore: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,11 +15,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780499049,
-        "narHash": "sha256-oqS4fc4qgrfP5TFl/IHW39fsERtSWNufQQp0QoDxb/Q=",
+        "lastModified": 1786106879,
+        "narHash": "sha256-cg547mpcWOp85aQn8i11LnHdPGcibSaVjDY53RQF0GA=",
         "owner": "opendefensecloud",
         "repo": "dev-kit",
-        "rev": "9fe77282c8260284d4efdb69d19b883e52e9a4d8",
+        "rev": "170f07afc6757b8cdcb0d32a89ebb058a5431631",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780434986,
-        "narHash": "sha256-y+HEGGFmDGO/hkRmBgt+bcGNsn7zt8UkM+KQnWhlk38=",
+        "lastModified": 1786187685,
+        "narHash": "sha256-yM+cGzDhRpvbYI0zpCG/wVha6Jbcs6Jlb647wzYbQEk=",
         "owner": "purpleclay",
         "repo": "go-overlay",
-        "rev": "7f70305782ff557ca1e1c8f0dc9bdb71f6255122",
+        "rev": "1f5ea3876f1d63709538c395b451f79dc6853229",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update flake to fix dev shell reporting unsupported golang version.

## Checklist
- [x] ~Tests added/updated~
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
