### PR TITLE
chore: update dev-kit and configure improved branch-protection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Include ODC common make targets
-DEV_KIT_VERSION := v1.0.11
+DEV_KIT_VERSION := v1.0.13
 -include common.mk
 common.mk:
 	@[ -f .common.mk-download ] || \
@@ -20,6 +20,18 @@ MANAGER_IMG ?= manager:latest
 DOCS_IMG ?= arc-docs:latest
 
 ENVTEST_K8S_VERSION ?= 1.36.1
+
+# Repo branch protection settings
+REPO_ADMIN_BYPASS := false
+REPO_REQUIRED_APPROVING_REVIEW_COUNT := 1
+REPO_REQUIRE_CODE_OWNER_REVIEW := false
+REPO_REQUIRE_BRANCH_UP_TO_DATE := true
+REPO_STATUS_CHECKS := ["check", "CodeQL"]
+REPO_RULESET_BRANCHES := ["release/*"]
+REPO_ALLOW_MERGE_COMMIT := true
+REPO_ALLOW_SQUASH_MERGE := false
+REPO_ALLOW_REBASE_MERGE := false
+REPO_REQUIRE_LAST_PUSH_APPROVAL := true
 
 # Kind node image for local/e2e clusters — defaults to track ENVTEST_K8S_VERSION
 # so envtest (`make test`) and Kind-based clusters (`make dev-cluster`,


### PR DESCRIPTION
## What
<!-- One sentence summary -->
related to https://github.com/opendefensecloud/odd-internal/issues/44

This PR updates the configured Github settings for the Solar repository.

In order to follow best practices regarding branch protection, we now have the following changes:

- Org Admins no longer can bypass the protect-main ruleset
- `check` `lint` `test` and `CodeQL` Checks need to succeed on the latest change in order for a PR to be merge-able
- Reviewers approval is only valid if they approved the latest commit of a PR.
- `squash` and `rebase` merges are now additionally prohibited.
- The rules for `main` also apply for any `release/*` branches (currently none)

## Testing

`make repo-settings` successfully applied the intended changes to the repo and the OpenSSF Scorecard now reports a 8/10 score for Branch-Protection.

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the development toolkit to the latest supported version.
  * Added configuration options for repository branch protection, including review requirements, status checks, branch rules, merge strategies, and approval settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->