### PR TITLE
fix(examples): keep relative access and support plain-HTTP sources

### DIFF
--- a/examples/ocm/artifact-type.yaml
+++ b/examples/ocm/artifact-type.yaml
@@ -15,5 +15,7 @@ spec:
       value: "0"
     - name: dstScheme
       value: "https"
+    - name: srcScheme
+      value: "https"
   workflowTemplateRef: # argo.ClusterWorkflowTemplate
     name: ocm-transfer-pipeline

--- a/examples/ocm/cluster-workflow-template.yaml
+++ b/examples/ocm/cluster-workflow-template.yaml
@@ -49,7 +49,10 @@ spec:
       - name: specVersion
       - name: scanSeverity # Additional parameter coming from ArtifactType
       - name: scanExitCode # Additional parameter coming from ArtifactType
-      - name: dstScheme    # Additional parameter coming from ArtifactType
+      - name: srcScheme
+        value: "https"
+      - name: dstScheme
+        value: "https"
 
   entrypoint: ocm-pipeline
 
@@ -113,6 +116,8 @@ spec:
           set -euo pipefail
           export HOME=/tmp
 
+          src_host=$(echo '{{workflow.parameters.srcRemoteURL}}' | sed 's#^[a-z][a-z0-9+.-]*://##')
+
           if [ "{{workflow.parameters.srcSecret}}" = "true" ]; then
               echo "type: generic.config.ocm.software/v1
           configurations:
@@ -120,7 +125,7 @@ spec:
               consumers:
                 - identity:
                     type: OCIRegistry
-                    hostname: $(echo '{{workflow.parameters.srcRemoteURL}}' | cut -d : -f 1)
+                    hostname: $(echo "$src_host" | cut -d : -f 1)
                   credentials:
                     - type: Credentials
                       properties:
@@ -130,9 +135,9 @@ spec:
 
           echo "Transfering to CTF..."
           if [ -n "{{workflow.parameters.specRepo}}" ]; then
-            component_url={{workflow.parameters.srcRemoteURL}}/{{workflow.parameters.specRepo}}//{{workflow.parameters.specComponent}}:{{workflow.parameters.specVersion}}
+            component_url={{workflow.parameters.srcScheme}}://$src_host/{{workflow.parameters.specRepo}}//{{workflow.parameters.specComponent}}:{{workflow.parameters.specVersion}}
           else
-            component_url={{workflow.parameters.srcRemoteURL}}//{{workflow.parameters.specComponent}}:{{workflow.parameters.specVersion}}
+            component_url={{workflow.parameters.srcScheme}}://$src_host//{{workflow.parameters.specComponent}}:{{workflow.parameters.specVersion}}
           fi
           ocm transfer component "$component_url" -r --copy-resources --copy-sources /data/ctf
 
@@ -198,6 +203,9 @@ spec:
         source: |
           set -euo pipefail
           export HOME=/tmp
+
+          dst_host=$(echo '{{workflow.parameters.dstRemoteURL}}' | sed 's#^[a-z][a-z0-9+.-]*://##')
+
           if [ "{{workflow.parameters.dstSecret}}" = "true" ]; then
               echo "type: generic.config.ocm.software/v1
           configurations:
@@ -205,7 +213,7 @@ spec:
               consumers:
                 - identity:
                     type: OCIRegistry
-                    hostname: $(echo '{{workflow.parameters.dstRemoteURL}}' | cut -d : -f 1)
+                    hostname: $(echo "$dst_host" | cut -d : -f 1)
                   credentials:
                     - type: Credentials
                       properties:
@@ -214,8 +222,8 @@ spec:
           fi
 
           if [ -n "{{workflow.parameters.specRepo}}" ]; then
-            dst_url={{workflow.parameters.dstScheme}}://{{workflow.parameters.dstRemoteURL}}/{{workflow.parameters.specRepo}}
+            dst_url={{workflow.parameters.dstScheme}}://$dst_host/{{workflow.parameters.specRepo}}
           else
-            dst_url={{workflow.parameters.dstScheme}}://{{workflow.parameters.dstRemoteURL}}
+            dst_url={{workflow.parameters.dstScheme}}://$dst_host
           fi
-          ocm transfer ctf /data/ctf "$dst_url"
+          ocm -X preferrelativeaccess=true transfer ctf /data/ctf "$dst_url"


### PR DESCRIPTION
## What
Preserve `relativeOciReference` across an OCM transfer and make the source
registry scheme configurable in the ocm pipeline.
Relate to #747

## Why
Reltive access is dropped in the ocm exxample, a relativeOciReference types (`test/demo:0.1`) are silently transformed to  ociArtifact types (`https:zot.svc.cluster/test/demo:0.1`) 

## Testing
Extensive testing is being done in the #747 counterpart of the feature on the solar side, where catalog chaining has its own e2e suite.

## Notes for reviewers
-

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable source and destination URL schemes to OCM artifact workflows, defaulting to HTTPS.
  * Improved handling of registry URLs by normalizing hostnames and rebuilding transfer and push URLs with the selected schemes.
  * Updated credential configuration to use the normalized registry hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->