### PR TITLE
fix: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,11 +15,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786106879,
-        "narHash": "sha256-cg547mpcWOp85aQn8i11LnHdPGcibSaVjDY53RQF0GA=",
+        "lastModified": 1786699445,
+        "narHash": "sha256-kPMlxqzLQhYUtBrBHxTkU6iaElWvZ/dQdCIbe22ceuo=",
         "owner": "opendefensecloud",
         "repo": "dev-kit",
-        "rev": "170f07afc6757b8cdcb0d32a89ebb058a5431631",
+        "rev": "8cb6197cd7a2f93bc5cf12c689e48df615f1dbde",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786187685,
-        "narHash": "sha256-yM+cGzDhRpvbYI0zpCG/wVha6Jbcs6Jlb647wzYbQEk=",
+        "lastModified": 1787202193,
+        "narHash": "sha256-MF6EmU2l9K5lnpKZ22tLq0MEbzUadP5a68l0S6y9O54=",
         "owner": "purpleclay",
         "repo": "go-overlay",
-        "rev": "1f5ea3876f1d63709538c395b451f79dc6853229",
+        "rev": "58a161efa965ff26edf9387c6c6a85be659226fd",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What
Update the flake so it supports the latest golang version again.

## Checklist
- [x] ~Tests added/updated~
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
