### PR TITLE
fix(ci): resolve zizmor and actionlint findings in workflows

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -119,21 +119,28 @@ jobs:
         if: ${{ env.ACT != 'true' }}
         env:
           COSIGN_EXPERIMENTAL: 1
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.image.outputs.digest }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          IFS=',' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
-          for tag in "${TAGS[@]}"; do
+          IFS=',' read -ra TAG_LIST <<< "$TAGS"
+          for tag in "${TAG_LIST[@]}"; do
             cosign sign \
-              -a "repo=${{ github.repository }}" \
-              -a "workflow=${{ github.workflow }}" \
-              -a "sha=${{ github.sha }}" \
+              -a "repo=$REPO" \
+              -a "workflow=$WORKFLOW_NAME" \
+              -a "sha=$COMMIT_SHA" \
               --yes \
-              "$tag"@${{ steps.image.outputs.digest }}
+              "$tag@$DIGEST"
           done
       - name: Extract first tag
         id: first-tag
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          IFS=$'\n' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
-          echo "tag=${TAGS[0]}" >> $GITHUB_OUTPUT
+          IFS=$'\n' read -ra TAG_LIST <<< "$TAGS"
+          echo "tag=${TAG_LIST[0]}" >> "$GITHUB_OUTPUT"
       - name: Generate SBOM
         if: ${{ env.ACT != 'true' }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -28,5 +28,7 @@ jobs:
           git config --global user.name "Docs Deploy"
           git config --global user.email "docs.deploy@opendefense.cloud"
       - name: Build Docs Website
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest
+          mike deploy --push --update-aliases "$RELEASE_TAG" latest

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -73,25 +73,27 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             # Remove 'v' prefix from tag if present (e.g., v0.1.0 -> 0.1.0)
             VERSION=${GITHUB_REF_NAME#v}
-            echo "source=tag" >> $GITHUB_OUTPUT
+            echo "source=tag" >> "$GITHUB_OUTPUT"
           else
             # For pull requests and other refs, compute a semver version
             # Format: 0.0.0-pr.<pr_number>.<short_sha>
-            PR_NUMBER=${{ github.event.pull_request.number }}
-            SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+            SHORT_SHA=${GITHUB_SHA:0:7}
             VERSION="0.0.0-pr.${PR_NUMBER}.${SHORT_SHA}"
-            echo "source=computed" >> $GITHUB_OUTPUT
+            echo "source=computed" >> "$GITHUB_OUTPUT"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Chart version: ${VERSION}"
 
       - name: Update chart version and appVersion
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
           for chart in charts/*/; do
             if [ -f "${chart}Chart.yaml" ]; then
               CHART_NAME=$(basename "${chart}")
@@ -108,6 +110,8 @@ jobs:
           done
 
       - name: Package and publish Helm charts
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           for chart in charts/*/; do
             if [ -f "${chart}Chart.yaml" ]; then
@@ -118,12 +122,12 @@ jobs:
               helm package "${chart}"
 
               # Push to OCI registry
-              PACKAGE=$(ls ${CHART_NAME}-*.tgz)
-              helm push "${PACKAGE}" oci://ghcr.io/${{ github.repository_owner }}/charts &> push-metadata.txt
-              echo "✓ Published ${PACKAGE} to ghcr.io/${{ github.repository_owner }}/charts"
+              PACKAGE=$(ls "${CHART_NAME}"-*.tgz)
+              helm push "${PACKAGE}" "oci://ghcr.io/${REPO_OWNER}/charts" &> push-metadata.txt
+              echo "✓ Published ${PACKAGE} to ghcr.io/${REPO_OWNER}/charts"
               CHART_DIGEST=$(awk '/Digest: /{print $2}' push-metadata.txt)
-              echo "CHART_DIGEST=${CHART_DIGEST}" | tee -a $GITHUB_ENV
+              echo "CHART_DIGEST=${CHART_DIGEST}" | tee -a "$GITHUB_ENV"
 
-              cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/${CHART_NAME}@${CHART_DIGEST}"
+              cosign sign --yes "ghcr.io/${REPO_OWNER}/charts/${CHART_NAME}@${CHART_DIGEST}"
             fi
           done

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -61,4 +61,4 @@ jobs:
           IMAGE_TAG: ${{ inputs.image-tag }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          make test-e2e E2E_IMAGE_SOURCE=$E2E_IMAGE_SOURCE TAG=$IMAGE_TAG REGISTRY=$REGISTRY
+          make test-e2e E2E_IMAGE_SOURCE="$E2E_IMAGE_SOURCE" TAG="$IMAGE_TAG" REGISTRY="$REGISTRY"


### PR DESCRIPTION
## What

Fixes everything `zizmor` and `actionlint` flag in `.github/workflows/`:

- template-injection in `docker.yaml`, `docs-release.yaml`, `helm-publish.yaml` -> expressions moved into `env:`
- `security-events: write` in `osv-scanner.yml` moved from workflow level down to the two scan jobs
- shellcheck SC2086 / SC2193 across `docker.yaml`, `helm-publish.yaml`, `release.yaml`, `test-e2e.yaml`

## Why

The interesting one is `docs-release.yaml`, it interpolated `${{ github.event.release.tag_name }}` right into a `mike deploy` line, and that job runs with `contents: write` and `persist-credentials: true`. A tag name is attacker-shaped input, so it stays a value in `env:` now, not shell code.

`helm-publish.yaml` had a real bug next to the lint noise: `[[ "${{ github.ref }}" == refs/tags/* ]]` (SC2193). The expression is substituted before bash sees it, so the comparison was not doing what it looks like. Reads `$GITHUB_REF` now.

The osv-scanner change is just scoping, both jobs still get the same permissions, they are only granted per job instead of file-wide.

Two zizmor findings are intentionally left:

- `cache-poisoning` on `docker/setup-buildx-action` (low confidence) -> gha cache is wanted here, dropping it costs real build time
- `superfluous-actions` on `softprops/action-gh-release` -> swapping a pinned action for a hand-rolled `gh release` script in the signing job is a bigger change than a lint PR should carry. Happy to do it separately if we want it 🤷 

## Testing

Both linters clean except the two above:

```
$ actionlint
$ echo $?
0

$ zizmor --no-online-audits .github/workflows/
47 findings (45 suppressed): 1 informational, 0 low, 0 medium, 1 high
```

Before: `61 findings (51 suppressed, 7 unsafe fixes): 5 informational, 0 low, 1 medium, 4 high` plus 11 actionlint/shellcheck findings.

No behavior change intended, every edit is value-identical. Publish paths (docker sign, helm push, docs deploy, release) only run on tag/release, so they get their real test on the next release.

## Checklist
- [x] Tests added/updated (n/a, CI config only)
- [x] No breaking changes
- [x] Readable commit history
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved reliability of automated container image signing and publishing workflows.
  - Tightened documentation deployment permissions to use read access by default, with write access limited to deployment tasks.
  - Improved Helm chart versioning, packaging, publishing, and signing workflow consistency.
  - Enhanced end-to-end test workflow handling for image sources, tags, and registries containing special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->