### PR TITLE
ci: attach SLSA provenance to release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,11 +57,21 @@ jobs:
           find bin -type f ! -name checksums.txt | sort | xargs sha256sum > bin/checksums.txt
 
       - name: Attest build provenance
+        id: attest
         # actions/attest defaults to SLSA build provenance when no sbom-path or
         # predicate input is given.
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: 'bin/arc-*-*' # binaries only; runs before signing so the .sigstore.json bundles are not yet present
+
+      - name: Keep the provenance as a release asset
+        # The step above only writes to GitHub's attestation store. OpenSSF
+        # Scorecard's Signed-Releases check detects provenance by filename and
+        # never looks there, so ship the same bundle as *.intoto.jsonl. Verify
+        # with: gh attestation verify <binary> --bundle arc-<tag>.intoto.jsonl
+        env:
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: cp "${BUNDLE}" "bin/arc-${GITHUB_REF_NAME}.intoto.jsonl"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -73,7 +83,7 @@ jobs:
           cd bin
           for f in *; do
             [ -f "$f" ] || continue
-            case "$f" in *.sigstore.json) continue ;; esac
+            case "$f" in *.sigstore.json | *.intoto.jsonl) continue ;; esac
             # Emit a Sigstore bundle (signature + cert + Rekor proof), named
             # *.sigstore.json so OpenSSF Scorecard's Signed-Releases check
             # detects it. Don't revert to --output-signature/--output-certificate:


### PR DESCRIPTION
## What
Adds a `*.intoto.jsonl` SLSA provenance asset to each release.
Relates to https://github.com/opendefensecloud/solution-arsenal/issues/673

## Why
Release artefacts are cosign-signed keyless with a `*.sigstore.json` bundle
per file, which earns 8/10 on OpenSSF Scorecard's Signed-Releases check. The
remaining 2 points need a provenance file **present in the release's assets**.
We already run `actions/attest`, but it stores the attestation in GitHub's
attestation store, which Scorecard never inspects — so the check is capped
at 8/10.

## Testing
Workflow logic exercised locally with `act`:

- the provenance file stays out of `checksums.txt`
- cosign skip it
- it appears exactly once in the upload set

Not locally testable: `actions/attest` itself needs GitHub OIDC.

For remote testing on a release with attached attestation:
gh attestation verify <binary> --bundle <prefix>-<tag>.intoto.jsonl


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release packages now include a provenance attestation bundle, making artifact origin and integrity easier to verify.
  * Provenance files are included alongside release binaries for clearer artifact validation.

* **Bug Fixes**
  * Updated release signing behavior to avoid incorrectly signing provenance metadata files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->