### PR TITLE
ci: run workflows in the nix dev shell

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -11,17 +11,21 @@ on:
 jobs:
   check:
     runs-on: ubuntu-24.04
+    # go and the codegen tools come from the flake and tools.lock.
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - id: go-version
-        uses: opendefensecloud/dev-kit/.github/actions/get-go-version@f16fb83a8669ba840346929d9c45b9efe95c4da0 # v1.0.15
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Set up nix with the shared Cachix cache
+        uses: opendefensecloud/dev-kit/.github/actions/setup-nix@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
       - name: Run codegen
         run: |
           make codegen
       - name: Check for changes
-        uses: opendefensecloud/dev-kit/.github/actions/diff-check@f16fb83a8669ba840346929d9c45b9efe95c4da0 # v1.0.15
+        uses: opendefensecloud/dev-kit/.github/actions/diff-check@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -9,6 +9,7 @@ on:
       - "**/*.go"
       - ".github/workflows/golang.yaml"
       - ".golangci.yml"
+      - "flake.lock"
       - "flake.nix"
       - "go.mod"
       - "go.sum"
@@ -20,6 +21,7 @@ on:
       - "**/*.go"
       - ".github/workflows/golang.yaml"
       - ".golangci.yml"
+      - "flake.lock"
       - "flake.nix"
       - "go.mod"
       - "go.sum"
@@ -32,36 +34,67 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-24.04
-    outputs:
-      go-version: ${{ steps.go-version.outputs.version }}
+    # Tools (go, golangci-lint, shellcheck, addlicense) come from the flake
+    # and tools.lock. `make lint` runs both lint-no-golangci and golangci-lint.
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - id: go-version
-        uses: opendefensecloud/dev-kit/.github/actions/get-go-version@f16fb83a8669ba840346929d9c45b9efe95c4da0 # v1.0.15
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Set up nix with the shared Cachix cache
+        uses: opendefensecloud/dev-kit/.github/actions/setup-nix@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
-      - name: lint-license-and-shell
-        run: |
-          make lint-no-golangci
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
+      # actions/setup-go used to warm GOMODCACHE / GOCACHE for us. Nix
+      # provides the toolchain but not those caches, so restore them
+      # explicitly. The key is trust-scoped (pr/trusted) so a pull request
+      # cannot poison the cache used by builds of trusted refs.
+      - name: Cache Go module + build caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-
+            go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-
+      - name: lint
+        run: make lint
 
   test:
     needs: lint
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Set up nix with the shared Cachix cache
+        uses: opendefensecloud/dev-kit/.github/actions/setup-nix@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0
         with:
-          go-version: ${{ needs.lint.outputs.go-version }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
+      # See the lint job for rationale. Separate cache scope per job so lint
+      # (compile-side artefacts only) does not clobber test, which also builds
+      # envtest / ginkgo binaries.
+      - name: Cache Go module + build caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-cache-test-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-cache-test-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-
+            go-cache-test-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-
       - name: test
-        run: |
-          make test
+        run: make test
       - name: Convert coverage to lcov
         uses: jandelgado/gcov2lcov-action@e4612787670fc5b5f49026b8c29c5569921de1db # v1.2.0
         with:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -48,19 +48,23 @@ jobs:
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
-      # actions/setup-go used to warm GOMODCACHE / GOCACHE for us. Nix
-      # provides the toolchain but not those caches, so restore them
+      # actions/setup-go used to warm GOMODCACHE / GOCACHE for us, and
+      # golangci-lint-action kept golangci-lint's own analysis cache. Nix
+      # provides the toolchain but neither cache, so restore all three
       # explicitly. The key is trust-scoped (pr/trusted) so a pull request
-      # cannot poison the cache used by builds of trusted refs.
-      - name: Cache Go module + build caches
+      # cannot poison the cache used by builds of trusted refs, and it covers
+      # tools.lock / .golangci.yml because a golangci-lint version or config
+      # change invalidates its analysis results.
+      - name: Cache Go module, build and lint caches
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+            ~/.cache/golangci-lint
+          key: go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum', 'tools.lock', '.golangci.yml') }}-${{ github.sha }}
           restore-keys: |
-            go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-
+            go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum', 'tools.lock', '.golangci.yml') }}-
             go-cache-lint-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-
       - name: lint
         run: make lint

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -17,6 +17,10 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-24.04
+    # helm comes from the flake (dev-kit's defaultPkgs).
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -24,10 +28,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Helm
-        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+      - name: Set up nix with the shared Cachix cache
+        uses: opendefensecloud/dev-kit/.github/actions/setup-nix@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0
         with:
-          version: 'v4.2.4'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
 
       - name: Lint Helm charts
         run: |

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -34,6 +34,13 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ok-to-helm')) ||
       (github.event_name == 'release' && github.event.action == 'published')
 
+    # helm comes from the flake. cosign comes from cosign-installer on the
+    # runner PATH; nix develop inherits PATH so it remains reachable from
+    # inside the dev shell.
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
+
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -41,10 +48,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Helm
-        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+      - name: Set up nix with the shared Cachix cache
+        uses: opendefensecloud/dev-kit/.github/actions/setup-nix@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0
         with:
-          version: 'v4.2.4'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,11 @@ jobs:
         #   --bundle arc-<tag>.intoto.jsonl
         env:
           BUNDLE: ${{ steps.attest.outputs.bundle-path }}
-        run: cp "${BUNDLE}" "bin/arc-${GITHUB_REF_NAME}.intoto.jsonl"
+        run: |
+          # Tags may legally contain '/', which would turn the asset name into a
+          # path under a directory that does not exist and fail the release job.
+          asset_tag="${GITHUB_REF_NAME//\//-}"
+          cp "${BUNDLE}" "bin/arc-${asset_tag}.intoto.jsonl"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,16 @@ jobs:
       contents: write
       id-token: write # for keyless cosign sign-blob
       attestations: write # for build-provenance attestation
+    # go comes from the flake. cosign comes from cosign-installer on the
+    # runner PATH; nix develop inherits PATH so it remains reachable from
+    # inside the dev shell. No actions/cache here: this is a privileged
+    # signing job, so it deliberately does not share a Go cache with
+    # unprivileged workflows (cache poisoning). This replaces the previous
+    # setup-go `cache: false`.
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -23,21 +33,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Extract go version from flake.nix
-        id: get-go-version
-        run: |
-          GO_VERSION="$(sed -nE 's/^[[:space:]]*goVersion[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)";[[:space:]]*$/\1/p' flake.nix)"
-          if [ "$(printf '%s\n' "$GO_VERSION" | sed '/^$/d' | wc -l)" -ne 1 ]; then
-            echo "::error::Expected exactly one goVersion assignment in flake.nix"
-            exit 1
-          fi
-          echo "version=$GO_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Set up nix with the shared Cachix cache
+        uses: opendefensecloud/dev-kit/.github/actions/setup-nix@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0
         with:
-          go-version: ${{ steps.get-go-version.outputs.version }}
-          cache: false # privileged signing job: avoid shared cache (cache-poisoning)
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
 
       - name: Run tests
         run: make test

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -20,36 +20,40 @@ permissions:
 jobs:
   test-e2e:
     runs-on: ubuntu-24.04
+    # go, kind, kubectl and helm all come from the flake. The e2e suite
+    # creates the cluster itself via `make test-e2e`, pinned to
+    # KIND_NODE_IMAGE (derived from ENVTEST_K8S_VERSION) — the Makefile
+    # stays the single source of truth for the K8s version.
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - id: go-version
-        uses: opendefensecloud/dev-kit/.github/actions/get-go-version@f16fb83a8669ba840346929d9c45b9efe95c4da0 # v1.0.15
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - name: Set up nix with the shared Cachix cache
+        uses: opendefensecloud/dev-kit/.github/actions/setup-nix@7427f5e62c1c45ec058e3e2b483a75d9dbe48805 # v2.2.0
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
-      - name: Install Tools
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-signing-key: ${{ secrets.CACHIX_SIGNING_KEY }}
+      # actions/setup-go used to warm GOMODCACHE / GOCACHE for us; restore
+      # them explicitly now. Trust-scoped (pr/trusted) so a pull request
+      # cannot poison the cache used by builds of trusted refs.
+      - name: Cache Go module + build caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-cache-e2e-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-cache-e2e-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-${{ hashFiles('go.sum') }}-
+            go-cache-e2e-${{ github.event_name == 'pull_request' && 'pr' || 'trusted' }}-
+      - name: Report tool versions
         run: |
-          # Install kind. The e2e suite creates the cluster itself via
-          # `make test-e2e`, pinned to KIND_NODE_IMAGE (derived from
-          # ENVTEST_K8S_VERSION) — the Makefile is the single source of truth
-          # for the K8s version, so we only need the binary here.
-          KIND_VERSION="v0.31.0"
-          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
           kind version
-
-          # Install kubectl
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x ./kubectl
-          sudo mv ./kubectl /usr/local/bin/kubectl
           kubectl version --client
-
-          # Install helm
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-          helm version
+          helm version --short
       - name: Run E2E Test Suite
         env:
           E2E_IMAGE_SOURCE: ${{ inputs.is-local && 'local' || 'ghcr' }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Include ODC common make targets
-DEV_KIT_VERSION := v2.1.0
+DEV_KIT_VERSION := v2.2.0
 -include common.mk
 common.mk:
 	@[ -f .common.mk-download ] || \

--- a/flake.lock
+++ b/flake.lock
@@ -15,15 +15,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787918634,
-        "narHash": "sha256-d/GY4lc2ssP2ax6GGLaakYkXZcW8XM1IlFO98qd7sXQ=",
+        "lastModified": 1788351182,
+        "narHash": "sha256-3fOyooxR5RHBdnacI/dw/jxGvr+WJdauzE5iW+hvmAI=",
         "owner": "opendefensecloud",
         "repo": "dev-kit",
-        "rev": "3ce2ec4d731819f2ddcd5b6d9fba88979bb4c04f",
+        "rev": "7427f5e62c1c45ec058e3e2b483a75d9dbe48805",
         "type": "github"
       },
       "original": {
         "owner": "opendefensecloud",
+        "ref": "v2.2.0",
         "repo": "dev-kit",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     };
 
     dev-kit = {
-      url = "github:opendefensecloud/dev-kit";
+      url = "github:opendefensecloud/dev-kit/v2.2.0";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.go-overlay.follows = "go-overlay";
       inputs.flake-utils.follows = "flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
           inherit system;
           goVersion = "1.26.6";
           packages = [
-            pkgs.cosign
             pkgs.trivy
           ];
           preCommitHooks = {


### PR DESCRIPTION
## What
Run all six tool-installing workflows inside the nix dev shell, so CI and local
development share one toolchain definition.

Closes #441

## Why
CI installed `kind`/`kubectl`/`helm` by curl, Go via `setup-go`, helm via
`azure/setup-helm`, and `sed`-grepped the Go version out of `flake.nix` — while the
flake already pinned all of them. The nix preamble comes from dev-kit's `setup-nix`
action ([dev-kit#30](https://github.com/opendefensecloud/dev-kit/pull/30), v2.2.0),
proven in solution-arsenal#792.

## Testing
- **`make test` green** on dev-kit's sideload script — 6 suites, 67 specs. This
  needed real verification: ARC's own script was 43 lines behind and had never run
  that code path.
- **kind spike** — nixpkgs `kind v0.32.0` stood up a real `kindest/node:v1.36.1`
  cluster and scheduled a pod. `kubectl v1.36.3` vs a `v1.36.1` server is inside skew.
- `actionlint` clean (one pre-existing SC2086 in untouched `docker.yaml`);
  `update-action-pins` passes; dev shell resolves go/kind/kubectl/helm/shellcheck.
- **Needs this PR's CI:** `test-e2e` (it is `workflow_call`, driven by `docker.yaml`)
  and cachix cold-start cost.

## Notes for reviewers

**Two developer-visible changes.**

- **Committing no longer runs an osv-scanner scan** — inherited from dev-kit v2.0.0's
  `feat!: disable osv-scanner pre-commit hook by default`. Its condition holds here:
  `osv-scanner.yml` still scans every PR, every push to main, and weekly. `make scan`
  runs it locally.
- **`kubectl` moves off floating `stable.txt`** to the nixpkgs pin (1.36.3).
  Unavoidable when sourcing from nix, and better than a version that can drift ahead
  of the server. `helm` is a true no-op — v4.2.4 both before and after.

**cosign is unchanged.** `pkgs.cosign` is dropped from the flake because it was unused
and would have shadowed `cosign-installer` under a nix shell, silently changing which
cosign signs releases. The installer stays in all three signing workflows, one pin,
Renovate-managed — matching solution-arsenal, whose flake also has no cosign.

**Go caches are new, not scope creep.** `setup-go` warmed `GOMODCACHE`/`GOCACHE`
implicitly; dropping it without a replacement would regress. Keys are per-job and
trust-scoped (`pr`/`trusted`). `release.yaml` deliberately gets none — privileged
signing job, preserving the old `setup-go` `cache: false`.

**Both dev-kit pins now agree at v2.2.0.** The flake input was floating on a commit
older than v1.0.15. Adopting dev-kit's envtest sideloading needed the
`DEV_KIT_VERSION` bump anyway, since `common.mk` now provides the
`envtest-binaries-sideload` target ARC carried locally.

**Non-goal: `on.paths` gating.** `golang.yaml` keeps its path filters. `protect-main`
requires only `check` and `CodeQL`, and `codegen.yaml` has no filters, so nothing can
fail to report today — but if `lint`/`test` are ever made required, they must move to
a `changes` job first or a docs-only PR will never report.

**Scope was six workflows, not four** — `codegen.yaml` and `helm-publish.yaml` also
called `setup-go`/`setup-helm`.

**Three corrections for the issue text:** `test-e2e.yaml` installs no `yq` and no
`flux` (only kind, kubectl, helm); there is no `apt-get` anywhere in
`.github/workflows/`; `golangci-lint` comes from `tools.lock`, not nix.

## Checklist
- [ ] Tests added/updated <!-- n/a — CI and build config only -->
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling to version 2.2.0.
  * Standardized CI workflows on a Nix-based development environment with shared caching.
  * Improved Go module and build cache restoration for linting and tests.
  * Updated workflow change detection and diff validation.
  * Consolidated lint execution through the project’s Makefile.
  * Removed the local environment-test binary sideloading step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->